### PR TITLE
Cache temporary variables in IO_PICKLECACHE.obs when IO_Pickling

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,13 @@
 ===========================================================================
 
 ==========================
+ Changes from 4.3 -> 4.4:
+==========================
+
+  - Fix problem with IO_Pickling some very large objects
+
+
+==========================
  Changes from 4.2 -> 4.3:
 ==========================
 
@@ -200,5 +207,3 @@
   - follow Frank's suggestion to allow more than one package with a
     C-part to be linked to a statically compiled GAP, document this
   - release subversion revision 155 as Version 1.3
-
-

--- a/gap/pickle.gi
+++ b/gap/pickle.gi
@@ -35,6 +35,9 @@ InstallGlobalFunction( IO_AddToPickled,
     else
         Add(IO_PICKLECACHE.ids,id,pos);
         Add(IO_PICKLECACHE.nrs,Length(IO_PICKLECACHE.ids),pos);
+        # Store a reference here so the result of
+        # IO_MasterPointerNumber will not get reused by another object.
+        Add(IO_PICKLECACHE.obs,ob);
         return false;
     fi;
   end );
@@ -59,8 +62,7 @@ InstallGlobalFunction( IO_FinalizePickled,
     IO_PICKLECACHE.depth := IO_PICKLECACHE.depth - 1;
     if IO_PICKLECACHE.depth = 0 then
         # important to clear the cache:
-        IO_PICKLECACHE.ids := [];
-        IO_PICKLECACHE.nrs := [];
+        IO_ClearPickleCache();
     fi;
   end );
 
@@ -78,7 +80,7 @@ InstallGlobalFunction( IO_FinalizeUnpickled,
     IO_PICKLECACHE.depth := IO_PICKLECACHE.depth - 1;
     if IO_PICKLECACHE.depth = 0 then
         # important to clear the cache:
-        IO_PICKLECACHE.obs := [];
+        IO_ClearPickleCache();
     fi;
   end );
 


### PR DESCRIPTION
This bug took me a while to track down. I'm fairly convinced it is a bug, just that my PartialPerm and Transformation picklers are the first to uncover it.

The problem was hard to track down, the fix is easy :)

The problem is that the IO's PickleCache uses 'IO_MasterPointerNumber' (which gives the GAP memory bag number) to decide if two objects are the same. The problem is that if an IO_Pickle function creates a temporary variable which is recursively IO_Pickled (which several do), then this objects can be garbage collected, and another objects created with the same master pointer. IO's Pickle Cache then thinks these are the same object.

The easy fix is just to cache the object in IO_AddToPickled, which ensures no temporary is thrown away until we have finished pickling. While this might cause memory usage increase during IO_Pickle, during IO_Unpickle a reference to every object is stored anyway, so this can't make code break that worked before. At the same time, for clarity, I standardised on always calling IO_ClearPickleCache to clear out the cache, rather than trying to cleverly only clean out some parts of the cache.

The reason (I think) no-one has hit this before (although I haven't carefully checked every function), is you have to 

(a) create temporary variables
(b) create enough temporary variables that a garbage collection occurs
(c) those temporary variables must be 'complex enough' that IO_AddToPickled is called for them.

The PartialPerm and Transformation picklers both generate temporary lists, which hit all these bullet points.
