### PR TITLE
Fix IO_Write to handle long input that is not in IsStringRep

### DIFF
--- a/gap/io.gi
+++ b/gap/io.gi
@@ -557,12 +557,6 @@ InstallGlobalFunction( IO_Write, function( arg )
                   pos2 := pos2 + bytes;
               od;
               f!.wdata := 0;
-              # Perhaps we can write a big chunk:
-              if Length(st)-pos > f!.wbufsize then
-                  bytes := IO_write(f!.fd,st,pos,Length(st)-pos);
-                  if bytes = fail then return fail; fi;
-                  pos := pos + bytes;
-              fi;
           od;
           return Length(st);
       fi;


### PR DESCRIPTION
The C function IO_write expects the string input to be in IsStringRep,
but a bug in the GAP function IO_Write passed parts of long Strings
directly to IO_write, which lead to Strings not being writable when
the write buffer overflowed.
This patch makes IO_Write copy all input into the write buffer before
calling IO_write on the write buffer.
