### PR TITLE
Get return status from process

### DIFF
--- a/doc/main.xml
+++ b/doc/main.xml
@@ -1941,7 +1941,8 @@ original &GAP; SIGCHLD signal handler
 The functions returns either <K>fail</K> if an error occurred, or otherwise
 a record with components <K>out</K> and <K>err</K> which are bound
 to strings containing the full standard output and standard error
-of the called process.
+of the called process, and <K>status</K> which is the status returned from
+the exiting process.
 </Description>
 </ManSection>
 

--- a/gap/io.gi
+++ b/gap/io.gi
@@ -1534,7 +1534,7 @@ end );
 
 InstallGlobalFunction( IO_PipeThroughWithError,
 function(cmd,args,input)
-  local byt,chunk,err,erreof,inpos,nr,out,outeof,r,s,w;
+  local byt,chunk,err,erreof,inpos,nr,out,outeof,r,s,w,status;
 
   # Start the coprocess:
   s := IO_Popen3(cmd,args,false,false,false);
@@ -1615,9 +1615,13 @@ function(cmd,args,input)
           fi;
       fi;
   until outeof and erreof;
+  status := IO_WaitPid(s.pid, true);
+  # We have to unbind this here, as by default IO will do its own
+  # IO_WaitPid when we close stdout.
+  Unbind(s.stdout!.dowaitpid);
   IO_Close(s.stdout);
   IO_Close(s.stderr);
-  return rec( out := Concatenation(out), err := err );
+  return rec( out := Concatenation(out), err := err, status := status );
 end);
 
 InstallGlobalFunction( IO_PipeThrough,


### PR DESCRIPTION
This patch adds the return valud of waitpid for a process to the method IO_PipeThroughWithError. This means that IO_PipeThroughWithError now returns all the data from a process.

The patch is a little weird, to get around the fact that calling IO_Close normally calls waitpid and we need to stop that happening.