### PR TITLE
Add mkstemp mkdtemp

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,7 +50,7 @@ AC_FUNC_LSTAT_FOLLOWS_SLASHED_SYMLINK
 AC_FUNC_SELECT_ARGTYPES
 AC_TYPE_SIGNAL
 AC_FUNC_STAT
-AC_CHECK_FUNCS([dup2 gethostbyname lchown memset mkdir mkfifo rmdir select socket getprotobyname signal sigaction opendir readdir closedir rewinddir telldir seekdir unlink link rename symlink readlink accept bind chmod connect dup fchmod fchown stat fstat lstat getsockopt listen lstat mknod recv recvfrom send sendto setsockopt gettimeofday gmtime localtime getpid getppid kill gethostname getsockname])
+AC_CHECK_FUNCS([dup2 gethostbyname lchown memset mkdir mkfifo rmdir select socket getprotobyname signal sigaction opendir readdir closedir rewinddir telldir seekdir unlink link rename symlink readlink accept bind chmod connect dup fchmod fchown stat fstat lstat getsockopt listen lstat mknod mkstemp mkdtemp recv recvfrom send sendto setsockopt gettimeofday gmtime localtime getpid getppid kill gethostname getsockname])
 
 AC_CYGWIN
 AM_CONDITIONAL([SYS_IS_CYGWIN], [test "$CYGWIN" = "yes"])

--- a/doc/main.xml
+++ b/doc/main.xml
@@ -215,6 +215,8 @@ The following functions from the C library are made available as
 <C>mkdir</C>,
 <C>mkfifo</C>,
 <C>mknod</C>,
+<C>mkstemp</C>,
+<C>mkdtemp</C>,
 <C>open</C>,
 <C>opendir</C>,
 <C>pipe</C>,
@@ -744,6 +746,26 @@ For details see <Q><C>man 3 mkfifo</C></Q>.
 <Description>
 Create a special or ordinary file.
 For details see <Q><C>man 2 mknod</C></Q>.
+</Description>
+</ManSection>
+
+<ManSection>
+<Func Name="IO_mkstemp" Arg="template"
+      Comm="Create a temporary file and open it, avoiding race conditions."/>
+<Returns> an integer or <K>fail</K> </Returns>
+<Description>
+Create a special or ordinary file.
+For details see <Q><C>man 3 mkstemp</C></Q>.
+</Description>
+</ManSection>
+
+<ManSection>
+<Func Name="IO_mkdtemp" Arg="template"
+      Comm="Create a temporary directory and return its name."/>
+<Returns> a string or <K>fail</K> </Returns>
+<Description>
+Create a temporary directory.
+For details see <Q><C>man 3 mkdtemp</C></Q>.
 </Description>
 </ManSection>
 

--- a/src/io.c
+++ b/src/io.c
@@ -101,7 +101,8 @@ void __stack_chk_fail_local (void)
  * open, creat, read, write, close, unlink, lseek, opendir, readdir,
  * closedir, rewinddir, telldir, seekdir, link, rename, symlink, readlink,
  * rmdir, mkdir, stat, lstat, fstat, chmod, fchmod, chown, fchown, lchown,
- * mknod, mkfifo, dup, dup2, socket, bind, connect, gethostbyname, listen,
+ * mknod, mkstemp, mkdtemp, mkfifo, dup, dup2, socket, bind, connect,
+ * gethostbyname, listen,
  * accept, recv, recvfrom, send, sendto, getsockopt, setsockopt, select,
  * fork, execv, execvp, execve, pipe, exit, getsockname, gethostname,
  *
@@ -904,6 +905,48 @@ Obj FuncIO_mknod(Obj self,Obj path,Obj mode,Obj dev)
       } else
           return True;
   }
+}
+#endif
+
+#ifdef HAVE_MKSTEMP
+Obj FuncIO_mkstemp(Obj self,Obj template)
+{
+    Int fd;
+    if (!IS_STRING(template) || !IS_STRING_REP(template)) {
+        SyClearErrorNo();
+        return Fail;
+
+    } else {
+        fd = mkstemp((char *) CHARS_STRING(template));
+        if (fd < 0) {
+            SySetErrorNo();
+            return Fail;
+        } else {
+            return INTOBJ_INT(fd);
+        }
+    }
+}
+#endif
+
+#ifdef HAVE_MKDTEMP
+Obj FuncIO_mkdtemp(Obj self,Obj template)
+{
+    Obj res;
+    char *r;
+
+    if (!IS_STRING(template) || !IS_STRING_REP(template)) {
+        SyClearErrorNo();
+        return Fail;
+    } else {
+        r = mkdtemp((char *) CHARS_STRING(template));
+        if (r == NULL) {
+            SySetErrorNo();
+            return Fail;
+        } else {
+            C_NEW_STRING(res, strlen(r), r);
+            return res;
+        }
+    }
 }
 #endif
 
@@ -1958,6 +2001,18 @@ static StructGVarFunc GVarFuncs [] = {
   { "IO_mknod", 3, "path, mode, dev",
     FuncIO_mknod,
     "io.c:IO_mknod" },
+#endif
+
+#ifdef HAVE_MKSTEMP
+  { "IO_mkstemp", 1, "template",
+    FuncIO_mkstemp,
+    "io.c:IO_mkstemp" },
+#endif
+
+#ifdef HAVE_MKDTEMP
+  { "IO_mkdtemp", 1, "template",
+    FuncIO_mkdtemp,
+    "io.c:IO_mkstemp" },
 #endif
 
 #ifdef HAVE_MKFIFO


### PR DESCRIPTION
This just adds the low-level interface, and there are certainly also tests and documentation missing.

A known issue (this is common to most of the low-level interface) is that code potentially leaks file descriptors:
```
gap> IO_mkstemp("/tmp/tempfile.XXX");
4
gap>
```
(Of course at this point one can still manually `IO_close(4)`, but in code somewhere in the depths of functions this wouldn't be possible).