### PR TITLE
Add IO_CallWithTimeout, IO_CallWithTimeoutList

### DIFF
--- a/doc/main.xml
+++ b/doc/main.xml
@@ -2649,6 +2649,8 @@ dominates the communication time for a single result.
 </Description>
 </ManSection>
 
+<#Include Label="IO_CallWithTimeout"/>
+
 Note that the next parallel skeleton is a worker farm which
 is described in the following section.
 </Section>

--- a/gap/callwithtimeout.gd
+++ b/gap/callwithtimeout.gd
@@ -1,0 +1,51 @@
+#############################################################################
+##
+#F  IO_CallWithTimeout( <timeout>, <func>[, <arg1>[, <arg2>....]] )  
+##         . . call a function with a time limit
+#F  IO_CallWithTimeoutList( <timeout>, <func>, <arglist> )  
+##
+##  <#GAPDoc Label="IO_CallWithTimeout">
+##  <Index>Timeouts</Index>
+##  <ManSection>
+##  <Func Name="IO_CallWithTimeout" Arg='timeout, func, .....'/>
+##  <Func Name="IO_CallWithTimeoutList" Arg='timeout, func, arglist'/>
+##
+##  <Description>
+##    <C>IO_CallWithTimeout</C> and <C>IO_CallWithTimeoutList</C> allow calling a function
+##  with a limit on length of time it will run. The function is run inside a copy of the current GAP
+##  session, so any changes it makes to global variables are thrown away when the function finishes
+##  or times out.<P/>
+##
+##  <C>IO_CallWithTimeout</C> is variadic. 
+##  Any arguments to it beyond the first two are passed as arguments to <A>func</A>.
+##  <C>IO_CallWithTimeoutList</C> in contrast takes exactly three arguments, of which the third is a list
+##  (possibly empty) of arguments to pass to <A>func</A>. <P/>
+##
+##  If the call completes within the allotted time and returns a value <C>res</C>, the result of 
+##  <C>IO_CallWithTimeout[List]</C> is a length 2 list of the form <C> [ true, res ] </C>. <P/>
+##  
+##  If the call completes within the allotted time and returns no value, the result of 
+##  <C>IO_CallWithTimeout[List]</C> is a list of length 1 containing the value <C>true</C>.<P/>
+##
+##  If the call does not complete within the timeout, the result of <C>IO_CallWithTimeout[List]</C>
+##  is a list of length 1 containing the value <C>false</C>. <P/>
+##
+##  The timer is suspended during execution of a break loop and abandoned when you quit from a break loop.<P/>
+##
+##  The limit <A>timeout</A> is specified as a record. At present the following components are recognised
+##  <C>nanoseconds</C>, <C>microseconds</C>, <C>milliseconds</C>, <C>seconds</C>, 
+##  <C>minutes</C>, <C>hours</C>, <C>days</C> and <C>weeks</C>. Any of these 
+##  components which is present should be bound to a positive integer, rational or float and the times
+##  represented are totalled to give the actual timeout. As a shorthand, a single positive 
+##  integers may be supplied, and is taken as a number of microseconds.
+##  Further components are permitted and ignored, to allow for future functionality.<P/>
+##
+##  The precision of the timeouts is not guaranteed, and there is a system dependent upper limit on the timeout 
+##  which is typically about 8 years on 32 bit systems and about 30 billion years on 64 bit systems. Timeouts longer
+##  than this will be reduced to this limit.<P/>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+
+DeclareGlobalFunction("IO_CallWithTimeout");
+DeclareGlobalFunction("IO_CallWithTimeoutList");

--- a/gap/callwithtimeout.gi
+++ b/gap/callwithtimeout.gi
@@ -1,0 +1,69 @@
+#############################################################################
+##
+#F  IO_CallWithTimeout( <timeout>, <func>[, <arg1>[, <arg2>....]] )  
+##         . . call a function with a time limit
+#F  IO_CallWithTimeoutList( <timeout>, <func>, <arglist> )  
+##
+##
+
+InstallGlobalFunction("IO_CallWithTimeout",
+        function( timeout, func, arg... )
+    return IO_CallWithTimeoutList(timeout, func, arg);
+end );
+
+InstallGlobalFunction("IO_CallWithTimeoutList",
+    function(timeout, func, arglist )
+    local  process, nano, seconds, microseconds, callfunc, timeoutrec, ret;
+    process := function(name, scale)
+        local  val;
+        if IsBound(timeout.(name)) then
+            val := timeout.(name);
+            if IsRat(val) or IsFloat(val) then
+                nano := nano + Int(val*scale);
+            else
+                Error("IO_CallWithTimeout[List]: can't understand period of ",val," ",name,". Ignoring.");
+            fi;
+        fi;
+    end;
+    if IsInt(timeout) then
+        nano := 1000*timeout;
+    else
+        if not IsRecord(timeout) then
+            Error("IO_CallWithTimeout[List]: timeout must be an integer or record");
+            return fail;
+        fi;
+        nano := 0;
+        process("nanoseconds",1);
+        process("microseconds",1000);
+        process("milliseconds",1000000);
+        process("seconds",10^9);
+        process("minutes",60*10^9);
+        process("hours",3600*10^9);
+        process("days",24*3600*10^9);
+        process("weeks",7*24*3600*10^9);
+    fi;
+    if nano < 0 then
+        Error("Negative timeout is not permitted");
+        return fail;
+    fi;
+    seconds := QuoInt(nano, 10^9);
+    microseconds := QuoInt(nano mod 10^9, 1000);
+    if seconds = 0 and microseconds = 0 then
+        # zero or tiny timeout. just simulate timeout now
+        return fail;
+    fi;
+    # make sure it's a small int. Cap timeouts at about 8 years on
+    # 32 bit systems
+    seconds := Minimum(seconds,2^(8*GAPInfo.BytesPerVariable-4)-1);
+
+    callfunc := function() return CallFuncListWrap(func, arglist); end;
+    timeoutrec := rec(TimeOut := rec(tv_sec := seconds, tv_usec := microseconds));
+    ret := ParDoByFork( [callfunc], [ [] ], timeoutrec);
+    if ret = [ ] then
+        return [ false ];
+    elif Length(ret[1]) > 0 then
+        return [ true, ret[1][1] ];
+    else
+        return [ true ];
+    fi;
+end);

--- a/init.g
+++ b/init.g
@@ -29,6 +29,7 @@ ReadPackage("IO", "gap/realrandom.gd");
 ReadPackage("IO", "gap/http.gd");
 ReadPackage("IO", "gap/background.gd");
 ReadPackage("IO", "gap/iohub.gd");
+ReadPackage("IO", "gap/callwithtimeout.gd");
 
 ##
 ##  This program is free software: you can redistribute it and/or modify

--- a/read.g
+++ b/read.g
@@ -13,6 +13,7 @@ ReadPackage("IO", "gap/realrandom.gi");
 ReadPackage("IO", "gap/http.gi");
 ReadPackage("IO", "gap/background.gi");
 ReadPackage("IO", "gap/iohub.gi");
+ReadPackage("IO", "gap/callwithtimeout.gi");
 
 # We now create the possibility that other packages can provide pickling
 # and unpickling handlers.

--- a/tst/timeout.tst
+++ b/tst/timeout.tst
@@ -1,0 +1,23 @@
+gap> START_TEST("timeout.tst");
+gap> spinFor := function(ms, arg...) local t;
+> t := NanosecondsSinceEpoch() / 1000;
+> while NanosecondsSinceEpoch() / 1000 < t + ms do od;
+> if Length(arg) >= 1
+> then return arg[1]; else return; fi; end;
+function( ms, arg... ) ... end
+gap> spinFor(10);
+gap> spinFor(10,0);
+0
+gap> IO_CallWithTimeout(50000,spinFor,1);
+[ true ]
+gap> IO_CallWithTimeout(5000,spinFor,50000);
+[ false ]
+gap> IO_CallWithTimeout(50000,spinFor,1,1);
+[ true, 1 ]
+gap> IO_CallWithTimeoutList(50000,spinFor,[1,1]);
+[ true, 1 ]
+gap> IO_CallWithTimeoutList(5000,spinFor,[50000,1]);
+[ false ]
+gap> IO_CallWithTimeoutList(50000,spinFor,[1]);
+[ true ]
+gap> STOP_TEST( "timeout.tst", 640000);


### PR DESCRIPTION
This adds `IO_CallWithTimeout`, a function call `CallWithTimeout`.

To help existing users of `CallWithTimeout`, I tried to make this as exact a replacement as I could, so some parts of the interface don't look like other IO functions (for example, the complicated object for representing the time), which could in principle be factored out and used by other IO functions, if  people liked the idea.