### PR TITLE
Replace Print by Info in IO_Unpickle

### DIFF
--- a/gap/pickle.gi
+++ b/gap/pickle.gi
@@ -264,8 +264,10 @@ InstallMethod( IO_Unpickle, "for a file",
     elif Length(magic) < 4 then return IO_Nothing;
     fi;
     if not(IsBound(IO_Unpicklers.(magic))) then
-        Print("No unpickler for magic value \"",magic,"\"\n");
-        Print("Maybe you have to load a package for this to work?\n");
+        Info(InfoWarning, 1, "No unpickler for magic value \"",magic,"\"");
+        Info(InfoWarning, 
+             1, 
+             "Maybe you have to load a package for this to work?");
         return IO_Error;
     fi;
     up := IO_Unpicklers.(magic);


### PR DESCRIPTION
The purpose of this change is to allow the option to suppress the
printed output from `IO_Unpickle`, so that, for example, we can call this
function from another one to check if a file is pickled or not. 