### PR TITLE
Pickle for ctbl

### DIFF
--- a/gap/pickle.gd
+++ b/gap/pickle.gd
@@ -51,6 +51,7 @@ BindGlobal ("IO_Unpicklers", rec() );
 # ILIS  an immutable list
 # INTG  an integer
 # IREC  an immutable record
+# IRNG  an immutable range
 # ISTR  an immutable string
 # MF2M  a mutable compressed GF2 matrix
 # MF2V  a mutable compressed GF2 vector
@@ -58,6 +59,7 @@ BindGlobal ("IO_Unpicklers", rec() );
 # MF8V  a mutable compressed 8Bit vector
 # MLIS  a mutable list
 # MREC  a mutable record
+# MRNG  a mutable range
 # MSTR  a mutable string
 # OPER  a GAP operation, only its name is pickled
 # PERM  a permutation

--- a/tst/pickle.g
+++ b/tst/pickle.g
@@ -212,3 +212,11 @@ if List(floatlist, x -> ExtRepOfObj(x)) <>
    List(pickledlist, x -> ExtRepOfObj(x)) then
     Error(36);
 fi;
+
+rng:= IO_Unpickle( IO_Pickle( [ 1 .. 1000 ] ) );;
+if rng <> [ 1 .. 1000 ] then
+  Error( 37 );
+elif not IsRangeRep( rng ) then
+  Error( 38 );
+fi;
+

--- a/tst/pickle.g
+++ b/tst/pickle.g
@@ -220,3 +220,17 @@ elif not IsRangeRep( rng ) then
   Error( 38 );
 fi;
 
+g:= SymmetricGroup( 6 );;  tbl:= CharacterTable( g );;  Irr( tbl );;
+tbl2:= IO_Unpickle( IO_Pickle( tbl ) );;
+if not ( HasIrr( tbl ) and HasIrr( tbl2 ) ) then
+  Error( 39 );
+elif Irr( tbl ) <> Irr( tbl2 ) then
+  Error( 40 );
+elif not ( HasConjugacyClasses( UnderlyingGroup( tbl ) )
+           and HasConjugacyClasses( UnderlyingGroup( tbl2 ) ) ) then
+  Error( 41 );
+elif ConjugacyClasses( UnderlyingGroup( tbl ) )
+     <> ConjugacyClasses( UnderlyingGroup( tbl2 ) ) then
+  Error( 42 );
+fi;
+


### PR DESCRIPTION
The (un)pickling for character tables that is proposed here works if the package CTblLib is not available.
When CTblLib is available, it would make sense to extend the list of supported attributes of the character table in question by attributes that are declared in CTblLib.

(This shows the limitations of pickling in general and of IO_GenericObjectPickler/IO_GenericObjectUnpickler in particular.)