### PR TITLE
Fix typo in IO_HandleChildSignal

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -150,7 +150,7 @@ static void IO_HandleChildSignal(int retcode, int status)
    if (retcode > 0) {   /* One of our child processes terminated */
         if (WIFEXITED(status) || WIFSIGNALED(status)) {
 #ifdef GAP_HasCheckChildStatusChanged
-            if (!CheckChildStatusChanged(retcode, status)) {
+            if (CheckChildStatusChanged(retcode, status)) {
                 // GAP has dealt with the signal
             } else
 #endif


### PR DESCRIPTION
Embarassing typo (what I'm not sure about is why this code seemed to work previously...)

`CheckChildStatusChanged` returns 1 if the signal has been handled by GAP.

I plan on writing some more extensive tests of this functionality, to check what happens if we mix GAP and IO processes.