### PR TITLE
Install SIGCHLD Handler in tests

### DIFF
--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,4 +1,5 @@
 LoadPackage("IO");
+IO_InstallSIGCHLDHandler();
 d := DirectoriesPackageLibrary("IO", "tst");
 Test(Filename(d, "bugfix.tst"));
 Read(Filename(d, "testgap.g"));

--- a/tst/testgap.g
+++ b/tst/testgap.g
@@ -1,4 +1,5 @@
 LoadPackage("IO");
+IO_InstallSIGCHLDHandler();
 d := DirectoriesPackageLibrary("IO", "tst");
 
 # Too many things in this directory, we'll just list the tests we want to run


### PR DESCRIPTION
This little patch installs IO's signal handler in the tests.

We could do this separately in each test file, but I hope fairly soon this won't be required -- but let's at least get all the tests passing again.