### PR TITLE
Io forcehandler

### DIFF
--- a/doc/main.xml
+++ b/doc/main.xml
@@ -539,15 +539,11 @@ For details see <Q><C>man 2 fchown</C></Q>.
 <Returns> an integer or <K>fail</K> </Returns>
 <Description>
 Forks off a child process, which is an identical copy.
-For details see <Q><C>man 2 fork</C></Q>. Note that if you want to use the
+For details see <Q><C>man 2 fork</C></Q>.
+Note that <Ref Func="IO_fork"/> activates our SIGCHLD handler (see <Ref
+Func="IO_InstallSIGCHLDHandler"/>). Note that you must use the
 <Ref Func="IO_WaitPid"/> function to wait or check for the termination of
-child processes, you have to activate the SIGCHLD handler for this
-package beforehand by using the function <Ref
-Func="IO_InstallSIGCHLDHandler"/>. Note further that after that you cannot use
-the function <Ref Func="InputOutputLocalProcess" BookName="ref"/>
-any more, since its SIGCHLD handler does not work any more. To switch
-back to that functionality use the function <Ref
-Func="IO_RestoreSIGCHLDHandler"/>.
+child processes.
 </Description>
 </ManSection>
 
@@ -1094,7 +1090,10 @@ as a list of strings of the form <Q>key=value</Q>.
 Installs our SIGCHLD handler. This functions works as an idempotent. That
 is, calling it twice does exactly the same as calling it once. It returns
 <K>true</K> when it is called for the first time since then a pointer to
-the old signal handler is stored in a global variable.
+the old signal handler is stored in a global variable. This function is
+automatically called by any function which creates new processes,
+so never needs to be called unless the handler was explictly disabled with
+<Ref Func="IO_RestoreSIGCHLDHandler"/>
 See <Ref Func="IO_fork"/>.
 </Description>
 </ManSection>

--- a/example/fork.g
+++ b/example/fork.g
@@ -1,7 +1,6 @@
 # An example using fork:
 
 LoadPackage("io");
-IO_InstallSIGCHLDHandler();    # install correct signal handler
 
 pid := IO_fork();
 if pid < 0 then

--- a/gap/background.gi
+++ b/gap/background.gi
@@ -45,7 +45,6 @@ InstallMethod(BackgroundJobByFork, "for a function, a list and a record",
   [IsFunction, IsObject, IsRecord],
   function(fun, args, opt)
     local j, n;
-    IO_InstallSIGCHLDHandler();
     for n in RecNames(BackgroundJobByForkOptions) do
         if not(IsBound(opt.(n))) then
             opt.(n) := BackgroundJobByForkOptions.(n);

--- a/gap/forkparallel.g
+++ b/gap/forkparallel.g
@@ -23,7 +23,6 @@ DoParallelByFork := function(jobs,opt)
                           "jobs is [func,arglist{,func,arglist})"));
       return fail;
   fi;
-  IO_InstallSIGCHLDHandler();
   for n in RecNames(DoParallelOptions) do
       if not(IsBound(opt.(n))) then opt.(n) := DoParallelOptions.(n); fi;
   od;

--- a/gap/io.gi
+++ b/gap/io.gi
@@ -1006,7 +1006,6 @@ function(path,argv,stdinfd,stdoutfd,stderrfd)
   # standard output and standard error of the child process respectively.
   # It installs our signal handler
   local pid;
-  IO_InstallSIGCHLDHandler();   # to be able to use IO_WaidPID
   pid := IO_fork();
   if pid < 0 then return fail; fi;
   if pid = 0 then   # the child
@@ -1049,7 +1048,6 @@ InstallGlobalFunction( IO_Popen, function(arg)
   if path = fail then
       Error("Popen: <path> must refer to an executable file.");
   fi;
-  IO_InstallSIGCHLDHandler();   # to be able to use IO_WaidPID
   if mode = "r" then
       pipe := IO_pipe(); if pipe = fail then return fail; fi;
       pid := IO_ForkExecWithFDs(path,argv,0,pipe.towrite,2);
@@ -1109,7 +1107,6 @@ InstallGlobalFunction( IO_Popen2, function(arg)
   if path = fail then
       Error("Popen2: <path> must refer to an executable file.");
   fi;
-  IO_InstallSIGCHLDHandler();   # to be able to use IO_WaidPID
   pipe := IO_pipe(); if pipe = fail then return fail; fi;
   pipe2 := IO_pipe();
   if pipe2 = fail then
@@ -1164,7 +1161,6 @@ InstallGlobalFunction( IO_Popen3, function(arg)
   if path = fail then
       Error("Popen3: <path> must refer to an executable file.");
   fi;
-  IO_InstallSIGCHLDHandler();   # to be able to use IO_WaidPID
   pipe := IO_pipe(); if pipe = fail then return fail; fi;
   pipe2 := IO_pipe();
   if pipe2 = fail then
@@ -1267,7 +1263,6 @@ function( progs, infd, outfd, switcherror )
       Add(pipes,pipe);
   od;
 
-  IO_InstallSIGCHLDHandler();   # to be able to use IO_WaidPID
 
   pids := 0*[1..Length(progs)];
   for i in [1..Length(progs)] do

--- a/src/io.c
+++ b/src/io.c
@@ -115,12 +115,6 @@ void __stack_chk_fail_local (void)
  *
  * and perhaps:
  *   socketpair, getsockname, poll, setrlimit, getrlimit, getrusage, ulimit,
- * NOTE: There are some problems with respect to signal handling,
- *       because the code for InputOutputLocalProcess and things
- *       has a signal handler for SIGCHLD, which interferes with
- *       things. This is solved in the sense that our SIGCHLD handler
- *       can be switched on and off, thereby providing support for
- *       either InputOutputLocalProcess *or* fork/exec and friends.
  * not for the moment (portability or implementation problems):
  *   remove, scandir, ioctl? (absolutely unportable, as it seems),
  *   fcntl? (for file locking purposes), recvmsg, sendmsg,
@@ -1451,6 +1445,7 @@ Obj FuncIO_select(Obj self, Obj inlist, Obj outlist, Obj exclist,
 Obj FuncIO_fork(Obj self)
 {
   int res;
+  FuncIO_InstallSIGCHLDHandler(0);
   res = fork();
   if (res == -1) {
       SySetErrorNo();

--- a/tst/children.tst
+++ b/tst/children.tst
@@ -1,4 +1,4 @@
-gap> d := DirectoryCurrent();;
+gap> dir := DirectoryCurrent();;
 gap> scriptdir := DirectoriesLibrary( "tst/teststandard/processes/" );;
 gap> checkpl := Filename(scriptdir, "check.pl");;
 gap> runChild := function(ms, ignoresignals, useio)
@@ -7,7 +7,7 @@ gap> runChild := function(ms, ignoresignals, useio)
 >    if useio then
 >      return IO_Popen(checkpl, [String(time), signal], "r");
 >    else
->      return InputOutputLocalProcess(d, checkpl, [ String(time), signal]);
+>      return InputOutputLocalProcess(dir, checkpl, [ String(time), signal]);
 >    fi;
 >  end;;
 

--- a/tst/children.tst
+++ b/tst/children.tst
@@ -1,0 +1,29 @@
+gap> d := DirectoryCurrent();;
+gap> scriptdir := DirectoriesLibrary( "tst/teststandard/processes/" );;
+gap> checkpl := Filename(scriptdir, "check.pl");;
+gap> runChild := function(ms, ignoresignals, useio)
+>    local signal;
+>    if ignoresignals then signal := "1"; else signal := "0"; fi;
+>    if useio then
+>      return IO_Popen(checkpl, [String(time), signal], "r");
+>    else
+>      return InputOutputLocalProcess(d, checkpl, [ String(time), signal]);
+>    fi;
+>  end;;
+
+# if checkpl exists, GAP is also up-to-date enough to support
+# this test!
+gap> if checkpl <> fail then
+>   for i in [1..200] do
+>     args := List([1..20], x -> [Random([1..2000]), Random([false,true]), Random([false,true])]);
+>     children := List(args, x -> CallFuncList(runChild, x) );
+>     if ForAny(children, x -> x=fail) then Print("Failed producing child\n"); fi;
+>     for c in children do
+>       if IsFile(c) then
+>           IO_Close(c);
+>       else
+>           CloseStream(c);
+>       fi;
+>     od;
+>   od;
+> fi;

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,5 +1,4 @@
 LoadPackage("IO");
-IO_InstallSIGCHLDHandler();
 d := DirectoriesPackageLibrary("IO", "tst");
 Test(Filename(d, "bugfix.tst"));
 Read(Filename(d, "testgap.g"));

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,4 +1,5 @@
 LoadPackage("IO");
 d := DirectoriesPackageLibrary("IO", "tst");
 Test(Filename(d, "bugfix.tst"));
+Test(Filename(d, "children.tst"));
 Read(Filename(d, "testgap.g"));

--- a/tst/testgap.g
+++ b/tst/testgap.g
@@ -1,5 +1,4 @@
 LoadPackage("IO");
-IO_InstallSIGCHLDHandler();
 d := DirectoriesPackageLibrary("IO", "tst");
 
 # Too many things in this directory, we'll just list the tests we want to run


### PR DESCRIPTION
Ensure we run InstallSIGCHLDHandler whenever we call IO_Fork, so there should be no need for users to ever manually call it (I leave the function there, in case someone has called it in code manually).

Also add a test which creates many GAP and IO subprocesses mixed together and check they are all cleaned up correctly.

This does lead to one user-visible difference which should be noted in the release notes at some point -- it is now required to call `IO_WaitPid` on forked children. This was always required once IO's SIGCHLDHandler was active, but before you could call `IO_fork` without activating the handler.