### PR TITLE
Add IO_IgnorePid

### DIFF
--- a/doc/main.xml
+++ b/doc/main.xml
@@ -543,7 +543,7 @@ For details see <Q><C>man 2 fork</C></Q>.
 Note that <Ref Func="IO_fork"/> activates our SIGCHLD handler (see <Ref
 Func="IO_InstallSIGCHLDHandler"/>). Note that you must use the
 <Ref Func="IO_WaitPid"/> function to wait or check for the termination of
-child processes.
+child processes, or call <Ref Func="IO_IgnorePid"/> to ignore the child. 
 </Description>
 </ManSection>
 
@@ -1033,7 +1033,21 @@ describing PID and exit status. The second argument <A>wait</A> must
 be either <K>true</K> or <K>false</K>. In the first case, the call
 blocks until new information about a terminated child process is
 available. In the second case no such waiting is performed, the
-call returns immediately. See <Ref Func="IO_fork"/>.
+call returns immediately. See <Ref Func="IO_fork"/>. If you do not
+care about the return value of the process, call
+<Ref Func="IO_IgnorePid"/>.
+</Description>
+</ManSection>
+
+<ManSection>
+<Func Name="IO_IgnorePid" Arg="pid"
+      Comm="Disown a child process."/>
+<Returns> Nothing </Returns>
+<Description>
+Disowns a child process. This means there is no need to call
+<Ref Func="IO_WaitPid"/>. Calling <Ref Func="IO_WaitPid"/> on
+a pid which was previously passed to <Ref Func="IO_IgnorePid"/>
+may cause an infinite loop.F
 </Description>
 </ManSection>
 
@@ -1804,7 +1818,8 @@ Note that the SIGCHLD handler of the <Package>IO</Package> package is installed
 by this function (see <Ref Func="IO_InstallSIGCHLDHandler"/>) and that it
 lies in the responsibility of the caller to use <Ref Func="IO_WaitPid"/>
 to ask for the status information of all child processes after their
-termination.
+termination, or call <Ref Func="IO_IgnorePid"/> to ignore the return value
+of a process.
 </Description>
 </ManSection>
 

--- a/gap/io.gi
+++ b/gap/io.gi
@@ -1526,6 +1526,7 @@ InstallGlobalFunction( IO_SendStringBackground, function(f,st)
       IO_Close(f);
       IO_exit(0);
   fi;
+  IO_IgnorePid(pid);
   return true;
 end );
 

--- a/src/io.c
+++ b/src/io.c
@@ -137,6 +137,57 @@ static int pids[MAXCHLDS];         /* and this number! */
 static int fistats = 0;            /* First used entry */
 static int lastats = 0;            /* First unused entry */
 static int statsfull = 0;          /* Flag, whether stats FIFO full */
+
+
+// This function must only be called while IO's signal handler is disabled!
+static int findSignaledPid(int pidc)
+{
+    if (fistats == lastats && !statsfull) /* queue empty */
+        return -1;
+
+    int pos = fistats;
+    while (pids[pos] != pidc)
+    {
+        pos++;
+        if (pos >= maxstats) pos = 0;
+        if (pos == lastats) {
+            pos = -1;  /* None found */
+            break;
+        }
+    }
+    return pos;
+}
+
+// This function must only be called while IO's signal handler is disabled!
+static void removeSignaledPidByPos(int pos)
+{
+    if (fistats == lastats && !statsfull) /* queue empty */
+        return;
+
+    int newpos;
+    if (pos == fistats) {  /* this is the easy case: */
+        fistats++;
+        if (fistats >= maxstats) fistats = 0;
+    } else {  /* The more difficult case: */
+        do {
+            newpos = pos+1;
+            if (newpos >= maxstats) newpos = 0;
+            if (newpos == lastats) break;
+            stats[pos] = stats[newpos];
+            pids[pos] = pids[newpos];
+            pos = newpos;
+        } while(1);
+        lastats = pos;
+    }
+    statsfull = 0;
+}
+
+/* This does not have to be the same size as the array above */
+static int ignoredpids[MAXCHLDS];
+static int ignoredpidslen;
+
+static int IO_CheckForIgnoredPid( int pid );
+
 static RETSIGTYPE (*oldhandler)(int whichsig) = 0;  /* the old handler */
 
 static void IO_HandleChildSignal(int retcode, int status)
@@ -148,6 +199,9 @@ static void IO_HandleChildSignal(int retcode, int status)
                 // GAP has dealt with the signal
             } else
 #endif
+            if (IO_CheckForIgnoredPid(retcode)) {
+                // Previously registered with IO_IgnorePid
+            } else
             if (!statsfull) {
                 stats[lastats] = status;
                 pids[lastats++] = retcode;
@@ -196,10 +250,67 @@ Obj FuncIO_RestoreSIGCHLDHandler( Obj self )
   }
 }
 
+// The following function checks if a PID is marked as ignored.
+// Returns 1 if the PID was ignored, 0 otherwise.
+// This function must only be called while IO's signal handler is disabled!
+static int IO_CheckForIgnoredPid( int pid )
+{
+    int i;
+    // Make sure a new signal doesn't come in while looking at array
+    int found = 0;
+    for(i = 0; i < ignoredpidslen; ++i) {
+        if (ignoredpids[i] == pid) {
+            ignoredpids[i] = ignoredpids[ignoredpidslen - 1];
+            ignoredpidslen--;
+            found = 1;
+            break;
+        }
+    }
+    return found;
+}
+
+Obj FuncIO_IgnorePid(Obj self, Obj pid)
+{
+    Int pidc;
+    int pos;
+    if (!IS_INTOBJ(pid)) {
+        return Fail;
+    }
+    pidc = INT_INTOBJ(pid);
+
+    if (pidc < 0) {
+        return Fail;
+    }
+
+    // Make sure a new signal doesn't come in while we are changing array
+    signal(SIGCHLD, SIG_DFL);
+
+    pos = findSignaledPid(pidc);
+    if (pos != -1)
+    {
+        // This PID has already finished
+        removeSignaledPidByPos(pos);
+        signal(SIGCHLD,IO_SIGCHLDHandler);
+        return True;
+    }
+
+    if (ignoredpidslen < MAXCHLDS - 1) {
+        ignoredpids[ignoredpidslen] = pidc;
+        ignoredpidslen++;
+        signal(SIGCHLD,IO_SIGCHLDHandler);
+    }
+    else {
+        Pr("#E Overflow in table of ignored processes",0,0);
+        signal(SIGCHLD,IO_SIGCHLDHandler);
+        return Fail;
+    }
+    return True;
+}
+
 Obj FuncIO_WaitPid(Obj self,Obj pid,Obj wait)
 {
   Int pidc;
-  int pos,newpos;
+  int pos;
   Obj tmp;
   int retcode,status;
   int reallytried;
@@ -217,16 +328,7 @@ Obj FuncIO_WaitPid(Obj self,Obj pid,Obj wait)
       else if (pidc == -1)  /* queue not empty and any entry welcome */
           pos = fistats;
       else {  /* Queue nonempty, so look for matching entry: */
-          pos = fistats;
-          do {
-              if (pids[pos] == pidc) break;
-              pos++;
-              if (pos >= maxstats) pos = 0;
-              if (pos == lastats) {
-                  pos = -1;  /* None found */
-                  break;
-              }
-          } while (1);
+          pos = findSignaledPid(pidc);
       }
       if (pos != -1) break;  /* we found something! */
       if (reallytried && wait != True) {
@@ -246,21 +348,7 @@ Obj FuncIO_WaitPid(Obj self,Obj pid,Obj wait)
   AssPRec(tmp,RNamName("pid"),INTOBJ_INT(pids[pos]));
   AssPRec(tmp,RNamName("status"),INTOBJ_INT(stats[pos]));
   /* Dequeue element: */
-  if (pos == fistats) {  /* this is the easy case: */
-      fistats++;
-      if (fistats >= maxstats) fistats = 0;
-  } else {  /* The more difficult case: */
-      do {
-          newpos = pos+1;
-          if (newpos >= maxstats) newpos = 0;
-          if (newpos == lastats) break;
-          stats[pos] = stats[newpos];
-          pids[pos] = pids[newpos];
-          pos = newpos;
-      } while(1);
-      lastats = pos;
-  }
-  statsfull = 0;
+  removeSignaledPidByPos(pos);
   /* Reinstantiate our handler: */
   signal(SIGCHLD,IO_SIGCHLDHandler);
   return tmp;
@@ -2070,6 +2158,10 @@ static StructGVarFunc GVarFuncs [] = {
     FuncIO_select,
     "io.c:IO_select" },
 #endif
+
+  { "IO_IgnorePid", 1, "pid",
+    FuncIO_IgnorePid,
+    "io.c:IO_IgnorePid" },
 
 #if defined(HAVE_SIGACTION) || defined(HAVE_SIGNAL)
   { "IO_WaitPid", 2, "pid, wait",

--- a/tst/sendstringbackground.tst
+++ b/tst/sendstringbackground.tst
@@ -1,0 +1,5 @@
+gap> f := IO_File("/dev/null", "w");;
+gap> IsBound(HPCGAP) or ForAll([1..3000], x -> IO_SendStringBackground(f, "cheese"));
+true
+gap> IO_Close(f);
+true


### PR DESCRIPTION
This adds a new function, `IO_IgnorePid`, which can be used to mark a child as ignored.

Whenever `IO_fork` is called, the child PID should be passed to either `IO_IgnorePid` or to `IO_WaitPid`.