### PR TITLE
Add TCPStream to IO

### DIFF
--- a/doc/main.xml
+++ b/doc/main.xml
@@ -3233,6 +3233,8 @@ they may be arbitrarily self-referential.
 </Section>
 </Chapter>
 
+<#Include SYSTEM "_Chapter_TCP_Streams.xml">
+
 <Chapter>
     <Heading>License</Heading>
 

--- a/gap/TCPStream.gd
+++ b/gap/TCPStream.gd
@@ -1,0 +1,47 @@
+# This code is mostly based on xstream.g{d,i} from the SCSCP package
+
+DeclareInfoClass("InfoTCPSockets");
+
+
+#! @Description
+#! Printable version of an IP address
+# TODO: Move to IO package
+DeclareGlobalFunction("TCP_AddrToString");
+
+#! @Description
+#!  <Ref Filt="IsInputOutputTCPStream"/> is a subcategory of
+#!  <Ref BookName="ref" Filt="IsInputOutputStream"/>.
+#!  Streams in the category <Ref Filt="IsInputOutputTCPStream"/>
+#!  are created with the help of the function
+#!  <Ref Func="InputOutputTCPStream" Label="for client" /> with
+#!  one or two arguments dependently on whether they will be
+#!  used in the client or server mode. Examples of their creation
+#!  and usage will be given in subsequent sections.
+DeclareCategory( "IsInputOutputTCPStream", IsInputOutputStream );
+
+#! @Description
+#!  This is the representation used for streams in the
+#!  category <Ref Filt="IsInputOutputTCPStream"/>.
+DeclareRepresentation( "IsInputOutputTCPStreamRep",
+                       IsPositionalObjectRep, [ ] );
+
+InputOutputTCPStreamDefaultType :=
+  NewType( StreamsFamily,
+           IsInputOutputTCPStreamRep and IsInputOutputTCPStream);
+
+#! @Description
+#! Creates a listening TCP socket
+DeclareGlobalFunction("ListeningTCPSocket");
+
+#! @Description
+#! Start a TCP server
+DeclareGlobalFunction("StartTCPServer");
+
+#! @Description
+#! Connects to a remote TCP server and returns an InputOutputTCPStream or fail
+DeclareGlobalFunction("ConnectInputOutputTCPStream");
+
+#! @Description
+#! Accepts a connection on a listening TCP socket and returns an InputOutputTCPStream
+#! or fail
+DeclareGlobalFunction("AcceptInputOutputTCPStream");

--- a/gap/TCPStream.gd
+++ b/gap/TCPStream.gd
@@ -1,11 +1,17 @@
 # This code is mostly based on xstream.g{d,i} from the SCSCP package
 
+#! @Chapter TCP Streams
 DeclareInfoClass("InfoTCPSockets");
-
 
 #! @Description
 #! Printable version of an IP address
-# TODO: Move to IO package
+#! @Arguments address
+#! @Example
+addr := IO_MakeIPAddressPort("127.0.0.1", 22);
+#! "\<\000\000\026\000\000\>\000\000\000\000\000\000\000\000"
+TCP_AddrToString(addr);
+#! "127.0.0.1"
+# @EndExample
 DeclareGlobalFunction("TCP_AddrToString");
 
 #! @Description
@@ -29,19 +35,40 @@ InputOutputTCPStreamDefaultType :=
   NewType( StreamsFamily,
            IsInputOutputTCPStreamRep and IsInputOutputTCPStream);
 
+#! @Arguments hostname, port
 #! @Description
-#! Creates a listening TCP socket
+#! Creates a listening TCP socket on the <A>hostname</A> and <A>port</A > given.
+#! @Returns a file descriptor
+#! @Log
+sock := ListeningTCPSocket("localhost", 22222);;
+socket_descriptor := IO_accept(sock, IO_MakeIPAddressPort("0.0.0.0", 0));;
+serverstream := AcceptInputOutputTCPStream(socket_descriptor);;
+#! @EndLog
 DeclareGlobalFunction("ListeningTCPSocket");
 
+#! @Arguments hostname, port, handerCallback
 #! @Description
-#! Start a TCP server
+#! Creates and starts a TCP server on the address given in
+#! <A>hostname</A> and the port given in <A>port</A>.
+#! If a client connects, the function <A>handlerCallback</A>
+#! is called with the address of the connected client as the first
+#! argument, and an <Ref Filt="IsInputOutputStream"/> which can be
+#! used to communicate with the client as second argument.
+#!
+#! Note this can currently only handle a single connection at a time.
+#!
+#! @Log
+#! @EndLog
 DeclareGlobalFunction("StartTCPServer");
 
+#! @Arguments hostname, port
 #! @Description
-#! Connects to a remote TCP server and returns an InputOutputTCPStream or fail
+#! Connects to the remote TCP server <A>hostname</A> at <A>port</A>
+#! and returns an InputOutputTCPStream on success or fail
 DeclareGlobalFunction("ConnectInputOutputTCPStream");
 
+#! @Arguments socket_descriptor
 #! @Description
-#! Accepts a connection on a listening TCP socket and returns an InputOutputTCPStream
-#! or fail
+#! Accepts a connection on a listening TCP socket given by <A>socket_descriptor</A>
+#! and returns an InputOutputTCPStream on success or fail
 DeclareGlobalFunction("AcceptInputOutputTCPStream");

--- a/gap/TCPStream.gd
+++ b/gap/TCPStream.gd
@@ -1,17 +1,19 @@
 # This code is mostly based on xstream.g{d,i} from the SCSCP package
 
 #! @Chapter TCP Streams
+#! @Section TCP Streams
+
 DeclareInfoClass("InfoTCPSockets");
 
 #! @Description
 #! Printable version of an IP address
 #! @Arguments address
 #! @Example
-addr := IO_MakeIPAddressPort("127.0.0.1", 22);
+#! addr := IO_MakeIPAddressPort("127.0.0.1", 22);
 #! "\<\000\000\026\000\000\>\000\000\000\000\000\000\000\000"
-TCP_AddrToString(addr);
+#! TCP_AddrToString(addr);
 #! "127.0.0.1"
-# @EndExample
+#! @EndExample
 DeclareGlobalFunction("TCP_AddrToString");
 
 #! @Description
@@ -35,15 +37,18 @@ InputOutputTCPStreamDefaultType :=
   NewType( StreamsFamily,
            IsInputOutputTCPStreamRep and IsInputOutputTCPStream);
 
-#! @Arguments hostname, port
 #! @Description
-#! Creates a listening TCP socket on the <A>hostname</A> and <A>port</A > given.
-#! @Returns a file descriptor
-#! @Log
-sock := ListeningTCPSocket("localhost", 22222);;
-socket_descriptor := IO_accept(sock, IO_MakeIPAddressPort("0.0.0.0", 0));;
-serverstream := AcceptInputOutputTCPStream(socket_descriptor);;
-#! @EndLog
+#!  Creates a listening TCP socket on the <A>hostname</A> and <A>port</A> given.
+#!
+#! @Arguments hostname, port
+#!
+#! @BeginExample
+#!  sock := ListeningTCPSocket("localhost", 22222);;
+#!  socket_descriptor := IO_accept(sock, IO_MakeIPAddressPort("0.0.0.0", 0));;
+#!  serverstream := AcceptInputOutputTCPStream(socket_descriptor);;
+#! @EndExample
+#! @Returns 
+#!  a file descriptor for a socket
 DeclareGlobalFunction("ListeningTCPSocket");
 
 #! @Arguments hostname, port, handerCallback
@@ -57,8 +62,6 @@ DeclareGlobalFunction("ListeningTCPSocket");
 #!
 #! Note this can currently only handle a single connection at a time.
 #!
-#! @Log
-#! @EndLog
 DeclareGlobalFunction("StartTCPServer");
 
 #! @Arguments hostname, port

--- a/gap/TCPStream.gi
+++ b/gap/TCPStream.gi
@@ -1,0 +1,243 @@
+InstallGlobalFunction(TCP_AddrToString,
+addr -> JoinStringsWithSeparator(List(addr{[5..8]},
+                                      x -> String(INT_CHAR(x))), "."));
+
+InstallGlobalFunction( StartTCPServer,
+function(hostname, port, handlerCallback)
+    local socket, addr, client, stream;
+    socket := ListeningTCPSocket(hostname, port);
+    while true do
+        # Currently we accept connections from anyone.
+        addr := IO_MakeIPAddressPort( "0.0.0.0", 0 );
+
+        # Accept connection, and open stream.
+        client := IO_accept(socket, addr);
+
+        # TODO: prettier
+        Info(InfoTCPSockets, 5, "Accepted connection from: ",
+             TCP_AddrToString(addr));
+        stream := AcceptInputOutputTCPStream(client);
+
+        # Handle connection
+        handlerCallback(addr, stream);
+    od;
+end);
+
+InstallGlobalFunction( ListeningTCPSocket,
+function(hostname, port)
+    local socket, client, desc, stream, res, bindaddr, listenname;
+
+    res := IO_gethostbyname(hostname);
+    if res = fail then
+        ErrorNoReturn("ListeningTCPSocket: lookup failed on address ",
+                      hostname);
+    fi;
+    bindaddr := res.addr[1];
+    listenname := res.name;
+
+    if not IsPosInt(port) or (port > 65535) then
+        ErrorNoReturn("ListeningTCPSocket:\n<port> must be ",
+                      "a positive integer no greater than 65535");
+    fi;
+
+    # Create TCP socket
+    Info(InfoTCPSockets, 5, "MitM server listening for connections...");
+    socket := IO_socket( IO.PF_INET, IO.SOCK_STREAM, "tcp" );
+    if socket = fail then
+        ErrorNoReturn("ListeningTCPSocket: failed to open socket:\n", 
+                      LastSystemError().message);
+    fi;
+
+    res := IO_bind(socket, IO_make_sockaddr_in(bindaddr, port));
+    if res = fail then
+        ErrorNoReturn("ListeningTCPSocket: failed to bind:\n", 
+                      LastSystemError().message);
+    fi;
+
+    Info(InfoTCPSockets, 5, "MitM server listening on ", listenname, " ", port);
+    # TODO: make the queue length a parameter
+    IO_listen(socket, 5);
+    return socket;
+end);
+
+InstallGlobalFunction( ConnectInputOutputTCPStream,
+function( hostname, port )
+    local lookup, sock, res, err, fio;
+
+    if not IsString( hostname ) then
+        Error("ConnectInputOutputTCPStream: <hostname> must be a string");
+    fi;
+    if not (IsInt(port) and port >= 0) then
+        Error("ConnectInputOutputTCPStream: <port> must be a non-negative integer");
+    fi;
+    lookup := IO_gethostbyname( hostname );
+    if lookup = fail then
+        Error("ConnectInputOutputTCPStream: cannot find hostname ", hostname);
+    fi;
+    sock := IO_socket( IO.PF_INET, IO.SOCK_STREAM, "tcp" );
+    res := IO_connect( sock, IO_make_sockaddr_in( lookup.addr[1], port ) );
+    if res = fail then
+        err := LastSystemError();
+        IO_close(sock);
+        Error("ConnectInputOutputTCPStream: ", err.message);
+    else
+        fio := IO_WrapFD( sock, IO.DefaultBufSize, IO.DefaultBufSize );
+        return Objectify( InputOutputTCPStreamDefaultType,
+                          [ fio, hostname, [ port ], false ] );
+    fi;
+end);
+
+InstallGlobalFunction( AcceptInputOutputTCPStream,
+function(socket_descriptor)
+    local fio;
+    if not (IsInt(socket_descriptor) and socket_descriptor >= 0) then
+        Error("AcceptInputOutputTCPStream: argument must be a non-negative integer");
+    fi;
+    fio := IO_WrapFD(socket_descriptor, IO.DefaultBufSize, IO.DefaultBufSize);
+    return Objectify( InputOutputTCPStreamDefaultType,
+                      [ fio, "socket descriptor", [ socket_descriptor ], false ] );
+end);
+
+InstallMethod( ViewObj, "for ioTCPstream",
+               [ IsInputOutputTCPStreamRep and IsInputOutputStream ],
+function(stream)
+    Print("<");
+    if IsClosedStream(stream) then
+        Print("closed ");
+    fi;
+    Print("input/output TCP stream to ",stream![2],":", stream![3][1], ">");
+end);
+
+InstallMethod( PrintObj, "for ioTCPstream",
+               [ IsInputOutputTCPStreamRep and IsInputOutputStream ],
+               ViewObj);
+
+InstallMethod( ReadByte, "for ioTCPstream",
+               [ IsInputOutputTCPStreamRep and IsInputOutputStream ],
+function(stream)
+    local buf;
+    buf := IO_Read( stream![1], 1 );
+    if buf = fail or Length(buf) = 0 then
+        stream![4] := true;
+        return fail;
+    else
+        stream![4] := true;
+        return INT_CHAR(buf[1]);
+    fi;
+end);
+
+InstallMethod( ReadLine, "for ioTCPstream",
+               [ IsInputOutputTCPStreamRep and IsInputOutputStream ],
+function( stream )
+    local sofar, chunk;
+    sofar := IO_Read( stream![1], 1 );
+    if sofar = fail or Length(sofar) = 0 then
+        stream![4] := true;
+        return fail;
+    fi;
+    while sofar[ Length(sofar) ] <> '\n' do
+        chunk := IO_Read( stream![1], 1);
+        if chunk = fail or Length(chunk) = 0 then
+            stream![4] := true;
+            return sofar;
+        fi;
+        Append( sofar, chunk );
+    od;
+    return sofar;
+end);
+
+BindGlobal( "ReadAllIoTCPStream",
+function(stream, limit)
+    local sofar, chunk, csize;
+    if limit = -1 then
+        csize := 20000;
+    else
+        csize := Minimum(20000,limit);
+        limit := limit - csize;
+    fi;
+    sofar := IO_Read(stream![1], csize);
+    if sofar = fail or Length(sofar) = 0 then
+        stream![4] := true;
+        return fail;
+    fi;
+    while limit <> 0  do
+        if limit = -1 then
+            csize := 20000;
+        else
+            csize := Minimum(20000,limit);
+            limit := limit - csize;
+        fi;
+        chunk := IO_Read( stream![1], csize);
+        if chunk = fail or Length(chunk) = 0 then
+            stream![4] := true;
+            return sofar;
+        fi;
+        Append(sofar,chunk);
+    od;
+    return sofar;
+end);
+
+
+InstallMethod( ReadAll, "for ioTCPstream",
+               [ IsInputOutputTCPStreamRep and IsInputOutputStream ],
+               stream ->  ReadAllIoTCPStream(stream, -1) );
+
+InstallMethod( ReadAll, "for ioTCPstream",
+               [ IsInputOutputTCPStreamRep and IsInputOutputStream, IsInt ],
+function( stream, limit )
+    if limit < 0 then
+        Error("ReadAll: negative limit not allowed");
+    fi;
+    return  ReadAllIoTCPStream(stream, limit);
+end);
+
+InstallMethod( WriteByte, "for ioTCPstream",
+               [ IsInputOutputTCPStreamRep and IsInputOutputStream, IsInt ],
+function(stream, byte)
+    local ret,s;
+    if byte < 0 or 255 < byte  then
+        Error( "<byte> must an integer between 0 and 255" );
+    fi;
+    s := [CHAR_INT(byte)];
+    ConvertToStringRep( s );
+    ret := IO_Write( stream![1], s );
+    if ret <> 1 then
+        return fail;
+    else
+        return true;
+    fi;
+end);
+
+InstallMethod( WriteLine, "for ioTCPstream",
+               [ IsInputOutputTCPStreamRep and IsInputOutputStream, IsString ],
+function( stream, string )
+    return IO_WriteLine( stream![1], string );
+end);
+
+InstallMethod( WriteAll, "for ioTCPstream",
+               [ IsInputOutputTCPStreamRep and IsInputOutputStream, IsString ],
+function( stream, string )
+    local byte;
+    for byte in string  do
+        if WriteByte( stream, INT_CHAR(byte) ) <> true  then
+            return fail;
+        fi;
+    od;
+    return true;
+end);
+
+InstallMethod( IsEndOfStream, "iostream",
+               [ IsInputOutputTCPStreamRep and IsInputOutputStream ],
+stream -> not IO_HasData( stream![1] ) );
+# TODO: when does this return true? -MT
+
+InstallMethod( CloseStream, "for ioTCPstream",
+               [ IsInputOutputTCPStreamRep and IsInputOutputStream ],
+function(stream)
+    IO_Close( stream![1] );
+    SetFilterObj( stream, IsClosedStream );
+end);
+
+InstallMethod( FileDescriptorOfStream, "for ioTCPstream",
+               [ IsInputOutputTCPStreamRep and IsInputOutputStream ],
+               stream -> IO_GetFD( stream![1] ) );

--- a/init.g
+++ b/init.g
@@ -29,6 +29,7 @@ ReadPackage("IO", "gap/realrandom.gd");
 ReadPackage("IO", "gap/http.gd");
 ReadPackage("IO", "gap/background.gd");
 ReadPackage("IO", "gap/iohub.gd");
+ReadPackage("IO", "gap/TCPStream.gd");
 
 ##
 ##  This program is free software: you can redistribute it and/or modify

--- a/makedoc.g
+++ b/makedoc.g
@@ -7,4 +7,4 @@ if fail = LoadPackage("AutoDoc", ">= 2016.01.21") then
     Error("AutoDoc 2016.01.21 or newer is required");
 fi;
 
-AutoDoc(rec( scaffold := rec( MainPage := false )));
+AutoDoc(rec( scaffold := rec( MainPage := false ), autodoc := true ));

--- a/read.g
+++ b/read.g
@@ -13,6 +13,7 @@ ReadPackage("IO", "gap/realrandom.gi");
 ReadPackage("IO", "gap/http.gi");
 ReadPackage("IO", "gap/background.gi");
 ReadPackage("IO", "gap/iohub.gi");
+ReadPackage("IO", "gap/TCPStream.gi");
 
 # We now create the possibility that other packages can provide pickling
 # and unpickling handlers.

--- a/tst/TCPStream.tst
+++ b/tst/TCPStream.tst
@@ -1,0 +1,190 @@
+# Contact a server (1)
+gap> stream := ConnectInputOutputTCPStream("www.google.com", 80);
+<input/output TCP stream to www.google.com:80>
+gap> IsInputOutputTCPStream(stream);
+true
+gap> WriteLine(stream, "GET");
+4
+gap> ReadLine(stream);
+"HTTP/1.0 200 OK\r\n"
+gap> CloseStream(stream);
+gap> stream;
+<closed input/output TCP stream to www.google.com:80>
+gap> Print(stream, "\n");
+<closed input/output TCP stream to www.google.com:80>
+
+# Contact a server (2)
+gap> stream := ConnectInputOutputTCPStream("www.google.com", 80);
+<input/output TCP stream to www.google.com:80>
+gap> WriteAll(stream, "DELE");
+true
+gap> WriteLine(stream, "TE");
+3
+gap> ReadAllIoTCPStream(stream, 40);
+"HTTP/1.0 400 Bad Request\r\nContent-Type: "
+gap> ReadAllIoTCPStream(stream, 40);
+"text/html; charset=UTF-8\r\nReferrer-Polic"
+gap> IsEndOfStream(stream);
+false
+gap> all := ReadAll(stream);;
+gap> Length(all) > 500;
+true
+gap> ReadByte(stream);
+fail
+gap> ReadLine(stream);
+fail
+gap> ReadAllIoTCPStream(stream, 40);
+fail
+gap> CloseStream(stream);
+gap> IsEndOfStream(stream);
+Error, Tried to check for data on closed file.
+gap> ReadAllIoTCPStream(stream, 40);
+Error, Tried to read from closed file.
+
+# Contact a server (3)
+gap> stream := ConnectInputOutputTCPStream("www.google.com", 80);;
+gap> WriteByte(stream, IntChar('G'));;
+gap> WriteByte(stream, IntChar('E'));;
+gap> WriteByte(stream, IntChar('T'));
+true
+gap> WriteLine(stream, "");
+1
+gap> ReadByte(stream) = IntChar('H');
+true
+gap> ReadLine(stream);
+"TTP/1.0 200 OK\r\n"
+gap> string := ReadAllIoTCPStream(stream, 21000);;
+gap> Length(string) <= 21000;
+true
+gap> string := ReadAll(stream, 21000);;
+gap> Length(string) <= 21000;
+true
+gap> CloseStream(stream);
+
+# Serve a local client
+gap> sock := IO_socket(IO.PF_INET, IO.SOCK_STREAM, "tcp");;
+gap> lookup := IO_gethostbyname("localhost");;
+gap> port := Random([20000..40000]);;
+gap> res := IO_bind( sock, IO_make_sockaddr_in(lookup.addr[1], port));
+true
+gap> IO_listen(sock, 5);
+true
+gap> child := IO_fork();;
+gap> if child = 0 then
+>   clientstream := ConnectInputOutputTCPStream("localhost", port);;
+>   WriteLine(clientstream, "12345");;
+>   if ReadLine(clientstream){[1..5]} = "54321" then
+>     WriteAll(clientstream, "Read successfully!");;
+>   fi;
+>   CloseStream(clientstream);
+>   FORCE_QUIT_GAP(0);
+> fi;
+gap> socket_descriptor := IO_accept(sock, IO_MakeIPAddressPort("0.0.0.0", 0));;
+gap> serverstream := AcceptInputOutputTCPStream(socket_descriptor);;
+gap> FileDescriptorOfStream(serverstream) = socket_descriptor;
+true
+gap> ReadLine(serverstream);
+"12345\n"
+gap> WriteLine(serverstream, "54321");
+6
+gap> ReadLine(serverstream);
+"Read successfully!"
+gap> wait := IO_WaitPid(child, true);;
+gap> wait.pid = child;
+true
+gap> wait.status;
+0
+gap> CloseStream(serverstream);
+
+# Serve a local client with ListeningTCPSocket
+gap> host := "localhost";;
+gap> port := Random([20000..40000]);;
+gap> sock := ListeningTCPSocket(host, port);;
+gap> child := IO_fork();;
+gap> if child = 0 then
+>   clientstream := ConnectInputOutputTCPStream(host, port);;
+>   WriteLine(clientstream, "12345");;
+>   if ReadLine(clientstream){[1..5]} = "54321" then
+>     WriteAll(clientstream, "Read successfully!");;
+>   fi;
+>   CloseStream(clientstream);
+>   FORCE_QUIT_GAP(0);
+> fi;
+gap> socket_descriptor := IO_accept(sock, IO_MakeIPAddressPort("0.0.0.0", 0));;
+gap> serverstream := AcceptInputOutputTCPStream(socket_descriptor);;
+gap> FileDescriptorOfStream(serverstream) = socket_descriptor;
+true
+gap> ReadLine(serverstream);
+"12345\n"
+gap> WriteLine(serverstream, "54321");
+6
+gap> ReadLine(serverstream);
+"Read successfully!"
+gap> wait := IO_WaitPid(child, true);;
+gap> wait.pid = child;
+true
+gap> wait.status;
+0
+gap> CloseStream(serverstream);
+
+# TCP_AddrToString
+gap> addr := IO_MakeIPAddressPort("123.234.87.6", 0);;
+gap> TCP_AddrToString(addr);
+"123.234.87.6"
+gap> addr := IO_MakeIPAddressPort("0.0.0.0", 0);;
+gap> TCP_AddrToString(addr);
+"0.0.0.0"
+
+# Errors
+gap> stream := ConnectInputOutputTCPStream("www.google.com", 80);;
+gap> ReadAll(stream, -1);
+Error, ReadAll: negative limit not allowed
+gap> WriteByte(stream, -1);
+Error, <byte> must an integer between 0 and 255
+gap> WriteByte(stream, 256);
+Error, <byte> must an integer between 0 and 255
+gap> CloseStream(stream);
+gap> ListeningTCPSocket("www.rubbish.rubbish", 12345);
+Error, ListeningTCPSocket: lookup failed on address www.rubbish.rubbish
+gap> ListeningTCPSocket("localhost", "a hundred");
+Error, ListeningTCPSocket:
+<port> must be a positive integer no greater than 65535
+gap> ListeningTCPSocket("www.google.com", 123);
+Error, ListeningTCPSocket: failed to bind:
+Cannot assign requested address
+gap> ConnectInputOutputTCPStream("localhost", 12345);
+Error, ConnectInputOutputTCPStream: Connection refused
+
+# Vandalise a stream to cause IO to fail
+gap> stream := ConnectInputOutputTCPStream("www.google.com", 80);;
+gap> stream![1]!.wbufsize := 0;;
+gap> stream![1]!.fd := "terrible input!";;
+gap> WriteLine(stream, "GET");
+fail
+gap> WriteAll(stream, "GET");
+fail
+gap> WriteByte(stream, IntChar('G'));
+fail
+gap> CloseStream(stream);
+
+# Vandalise IO variables to cause IO_socket to fail
+gap> inet := IO.PF_INET;;
+gap> IO.PF_INET := 0;;
+gap> ListeningTCPSocket("www.google.com", 80);
+Error, ListeningTCPSocket: failed to open socket:
+Address family not supported by protocol
+gap> IO.PF_INET := inet;;
+
+# InputOutputTCPStream errors
+gap> ConnectInputOutputTCPStream(80, "www.google.com");
+Error, ConnectInputOutputTCPStream: <hostname> must be a string
+gap> ConnectInputOutputTCPStream("www.google.com", "80");
+Error, ConnectInputOutputTCPStream: <port> must be a non-negative integer
+gap> ConnectInputOutputTCPStream("www.google.com", -80);
+Error, ConnectInputOutputTCPStream: <port> must be a non-negative integer
+gap> ConnectInputOutputTCPStream("www.g.michael", 80);
+Error, ConnectInputOutputTCPStream: cannot find hostname www.g.michael
+gap> AcceptInputOutputTCPStream(-1);
+Error, AcceptInputOutputTCPStream: argument must be a non-negative integer
+gap> AcceptInputOutputTCPStream("seventeen");
+Error, AcceptInputOutputTCPStream: argument must be a non-negative integer


### PR DESCRIPTION
For the [MathInTheMiddle](https://github.com/gap-packages/MathInTheMiddle) package we stole the TCP Streams from the [SCSCP](https://github.com/gap-packages/SCSCP) package and made them slightly more convenient. This now leads to an awkward duplication (and also a misplacement) of these TCP Streams.

Is the IO package a good place for this kind of thing, or do we want a separate package for this (where I am not sure what "this" is supposed to be)?

Obviously I'd add some more documentation either way before merging it (or putting it into a separate package).