### PR TITLE
Silence gcc: unused-variable

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -1560,7 +1560,6 @@ Obj FuncIO_execv(Obj self,Obj path,Obj Argv)
 {
     int argc;
     char *argv[1024];   /* Up to 1024 arguments */
-    char *envp[1024];   /* Up to 1024 environment entries */
     int i;
     Obj tmp;
 
@@ -1596,7 +1595,6 @@ Obj FuncIO_execvp(Obj self,Obj file,Obj Argv)
 {
     int argc;
     char *argv[1024];   /* Up to 1024 arguments */
-    char *envp[1024];   /* Up to 1024 environment entries */
     int i;
     Obj tmp;
 


### PR DESCRIPTION
Description: upstream: source: silence gcc: unused-variable
 At compilation time gcc (version 8.2.0) emits two unused-variable
 warnings, this patch is meant to silence it.
Origin: vendor, Debian
Author: Jerome Benoit calculus@rezozer.net
Last-Update: 2018-10-30