### PR TITLE
Rename io.c -> kernel.c

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@ GAPINSTALLLIB = $(BINARCHDIR)/io.so
 
 lib_LTLIBRARIES = io.la
 
-io_la_SOURCES = src/io.c
+io_la_SOURCES = src/kernel.c
 io_la_CPPFLAGS = $(GAP_CPPFLAGS)
 io_la_CFLAGS = $(GAP_CFLAGS)
 io_la_LDFLAGS = $(GAP_LDFLAGS) -module -avoid-version

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.68])
 AC_INIT([io], [package], [https://github.com/gap-packages/io/issues], [io], [http://gap-packages.github.io/io/])
-AC_CONFIG_SRCDIR([src/io.c])
+AC_CONFIG_SRCDIR([src/kernel.c])
 AC_CONFIG_HEADER([src/pkgconfig.h:cnf/pkgconfig.h.in])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([cnf])

--- a/doc/main.xml
+++ b/doc/main.xml
@@ -113,7 +113,7 @@ compiling <Q><F>gap</F></Q>. This directory also contains the &GAP; compiler scr
 
 <Verb>
     ./gac -o gap-static -p "-DIOSTATIC -I../../pkg/io/bin/BINDIR" \
-        -P "-static" ../../pkg/io/src/io.c
+        -P "-static" ../../pkg/io/src/kernel.c
 </Verb>
 
 Then copy your <Q><F>gap</F></Q> start script to, say, <Q><F>gaps</F></Q> and change the
@@ -136,7 +136,7 @@ in the ./gac command above. For the IO package, you have to add
 </Verb>
 to the string of the -p option and the file
 <Verb>
-  ../../pkg/io/src/io.c
+  ../../pkg/io/src/kernel.c
 </Verb>
 somewhere on the command line. As above, <Q><F>../..</F></Q> and
 <Q><F>BINDIR</F></Q> have to be replaced if you installed in a

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -1,6 +1,6 @@
 /***************************************************************************
 **
-*A  io.c               IO-package                            Max Neunhoeffer
+*A  kernel.c               IO-package                        Max Neunhoeffer
 **
 **
 **  Copyright (C) by Max Neunhoeffer


### PR DESCRIPTION
Several code coverage systems seem to confuse src/io.c in GAP with src/io.c in the IO package, so rename io.c in the IO package.

While this does seem a bit of an excessive fix, on the other hand it should be (hopefully!) the easiest way to improve coverage measurement.