### PR TITLE
MAXPATHLEN

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -97,6 +97,12 @@ void __stack_chk_fail_local (void)
 #endif
 #endif
 
+#ifdef __GNUC__
+#ifndef MAXPATHLEN
+#define MAXPATHLEN 4096
+#endif
+#endif
+
 
 /* Functions that are done:
  * open, creat, read, write, close, unlink, lseek, opendir, readdir,


### PR DESCRIPTION
Description: upstream: system parameters: MAXPATHLEN
 Provide MAXPATHLEN when it is not defined. This appears
 to be the case at least on the hurd-i386 architecture.
Origin: vendor, Debian
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2019-05-25