### PR TITLE
Handle crashing GAP in IO_CallWithTimeout

### DIFF
--- a/gap/callwithtimeout.gd
+++ b/gap/callwithtimeout.gd
@@ -31,8 +31,8 @@
 ##  result of <C>IO_CallWithTimeout[List]</C> is the list <C>[ true ]</C>.<P/>
 ##
 ##  If the call does not complete within the timeout, the result of
-##  <C>IO_CallWithTimeout[List]</C> is a list of length 1 containing the value
-##  <C>false</C>. <P/>
+##  <C>IO_CallWithTimeout[List]</C> is the list <C>[ false ]</C>. If the
+##  call causes GAP to crash or exit, the result is the list <C>[ fail ]</C>. <P/>
 ##
 ##  The timer is suspended during execution of a break loop and abandoned when
 ##  you quit from a break loop.<P/>

--- a/gap/callwithtimeout.gi
+++ b/gap/callwithtimeout.gi
@@ -61,6 +61,8 @@ InstallGlobalFunction("IO_CallWithTimeoutList",
     ret := ParDoByFork( [callfunc], [ [] ], timeoutrec);
     if ret = [ ] then
         return [ false ];
+    elif ret[1] = fail then
+        return [ fail ];
     elif Length(ret[1]) > 0 then
         return [ true, ret[1][1] ];
     else


### PR DESCRIPTION
Previously, IO_CallWithTimeout would crash if the forked GAP exited uncleanly / crashed. This makes it return `[fail]`. This makes it useful (for me at least!) for running experiments where you want to limit GAP's runtime, and also handle GAP running out of memory.