### PR TITLE
CI HACK: do not test `tst/sendstringbackground.tst` on macOS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,6 +51,9 @@ jobs:
           GAP_PKGS_TO_BUILD: ${{ matrix.GAP_PKGS_TO_BUILD }}
           HPCGAP: ${{ matrix.HPCGAP }}
       - uses: gap-actions/build-pkg@v1
+      # HACK: disable test file that currently fails on macOS in GitHub Actions
+      - run: rm tst/sendstringbackground.tst
+        if: ${{ runner.os == 'macOS' }}
       - uses: gap-actions/run-pkg-tests@v2
         with:
           NO_COVERAGE: ${{ matrix.NO_COVERAGE }}


### PR DESCRIPTION
This test passes on my computer (macOS 12), and @ChrisJefferson says there's not much he can really do about it. So he recommends to just not test it for now.