### PR TITLE
Avoid InstallValue, esp. for objects

### DIFF
--- a/gap/background.gd
+++ b/gap/background.gd
@@ -32,7 +32,6 @@ DeclareGlobalFunction("CompareTimes");
 
 DeclareOperation("BackgroundJobByFork", [IsFunction, IsObject]);
 DeclareOperation("BackgroundJobByFork", [IsFunction, IsObject, IsRecord]);
-DeclareGlobalVariable("BackgroundJobByForkOptions");
 DeclareGlobalFunction("BackgroundJobByForkChild");
 
 
@@ -48,16 +47,12 @@ DeclareOperation("Submit", [IsBackgroundJob, IsObject]);
 
 # Parallel skeletons:
 
-DeclareGlobalVariable("ParTakeFirstResultByForkOptions");
-
 DeclareOperation("ParTakeFirstResultByFork", [IsList, IsList]);
 DeclareOperation("ParTakeFirstResultByFork", [IsList, IsList, IsRecord]);
 # Arguments are:
 #   list of job functions
 #   list of argument lists
 #   options record
-
-DeclareGlobalVariable("ParDoByForkOptions");
 
 DeclareOperation( "ParDoByFork", [IsList, IsList]);
 DeclareOperation( "ParDoByFork", [IsList, IsList, IsRecord]);
@@ -67,7 +62,6 @@ DeclareOperation( "ParDoByFork", [IsList, IsList, IsRecord]);
 #   options record
 
 DeclareGlobalFunction("ParMapReduceWorker");
-DeclareGlobalVariable("ParMapReduceByForkOptions");
 
 DeclareOperation("ParMapReduceByFork",
   [IsList, IsFunction, IsFunction, IsRecord]);
@@ -78,7 +72,6 @@ DeclareOperation("ParMapReduceByFork",
 #   options record
 
 DeclareGlobalFunction("ParListWorker");
-DeclareGlobalVariable("ParListByForkOptions");
 
 DeclareOperation("ParListByFork",
   [IsList, IsFunction, IsRecord]);
@@ -100,8 +93,6 @@ DeclareRepresentation("IsWorkerFarmByFork", IsWorkerFarm,
 
 BindGlobal("WorkerFarmByForkType",
            NewType(WorkerFarmsFamily, IsWorkerFarmByFork));
-
-DeclareGlobalVariable("ParWorkerFarmByForkOptions");
 
 DeclareOperation("ParWorkerFarmByFork", [IsFunction, IsRecord]);
 # Arguments are:

--- a/gap/background.gi
+++ b/gap/background.gi
@@ -35,7 +35,7 @@ InstallMethod(BackgroundJobByFork, "for a function and a list",
     return BackgroundJobByFork(fun, args, rec());
   end );
 
-InstallValue(BackgroundJobByForkOptions,
+BindGlobal("BackgroundJobByForkOptions",
   rec(
     TerminateImmediately := false,
     BufferSize := 8192,
@@ -252,7 +252,7 @@ InstallMethod(ParTakeFirstResultByFork, "for two lists",
     return ParTakeFirstResultByFork(jobs, args, rec());
   end);
 
-InstallValue( ParTakeFirstResultByForkOptions,
+BindGlobal( "ParTakeFirstResultByForkOptions",
   rec( TimeOut := rec(tv_sec := false, tv_usec := false),
   ));
 
@@ -316,7 +316,7 @@ InstallMethod(ParDoByFork, "for two lists",
     return ParDoByFork(jobs, args, rec());
   end);
 
-InstallValue( ParDoByForkOptions,
+BindGlobal( "ParDoByForkOptions",
   rec( TimeOut := rec(tv_sec := false, tv_usec := false),
   ));
 
@@ -391,7 +391,7 @@ InstallMethod(ParDoByFork, "for two lists and a record",
     return results;
   end);
 
-InstallValue(ParMapReduceByForkOptions,
+BindGlobal("ParMapReduceByForkOptions",
   rec( TimeOut := rec(tv_sec := false, tv_usec := false),
   ));
 
@@ -447,7 +447,7 @@ InstallMethod(ParMapReduceByFork, "for a list, two functions and a record",
     return res2;
   end);
 
-InstallValue(ParListByForkOptions,
+BindGlobal("ParListByForkOptions",
   rec( TimeOut := rec(tv_sec := false, tv_usec := false),
   ));
 
@@ -496,7 +496,7 @@ InstallMethod(ParListByFork, "for a list, two functions and a record",
   end);
 
 
-InstallValue(ParWorkerFarmByForkOptions,
+BindGlobal("ParWorkerFarmByForkOptions",
   rec(
   ));
 

--- a/gap/http.gd
+++ b/gap/http.gd
@@ -10,7 +10,6 @@
 ##  side of the HTTP protocol.
 ##
 
-DeclareGlobalVariable( "HTTPTimeoutForSelect" );
 DeclareGlobalFunction( "OpenHTTPConnection" );
 DeclareGlobalFunction( "HTTPRequest" );
 DeclareGlobalFunction( "CloseHTTPConnection" );

--- a/gap/http.gi
+++ b/gap/http.gi
@@ -13,7 +13,7 @@
 # The following is given as argument to IO_Select for the timeout
 # values in a HTTP request.
 
-InstallValue( HTTPTimeoutForSelect, [fail,fail] );
+BindGlobal( "HTTPTimeoutForSelect", [fail,fail] );
 
 InstallGlobalFunction( OpenHTTPConnection,
   function(server,port)

--- a/gap/io.gd
+++ b/gap/io.gd
@@ -13,15 +13,10 @@ DeclareInfoClass("InfoIO");
 SetInfoLevel(InfoIO, 1);
 
 DeclareCategory( "IsFile", IsObject );
-DeclareGlobalVariable( "FileType" );
 DeclareAttribute( "ProcessID", IsFile );
 
 BindGlobal( "IO_ResultsFamily", NewFamily( "IO_ResultsFamily" ) );
 DeclareCategory( "IO_Result", IsComponentObjectRep );
-DeclareGlobalVariable( "IO_Error" );
-DeclareGlobalVariable( "IO_Nothing" );
-DeclareGlobalVariable( "IO_OK" );
-DeclareGlobalVariable( "IO_EOF" );    # End of file marker
 
 DeclareGlobalFunction( "IO_WrapFD" );
 DeclareGlobalFunction( "IO_File" );

--- a/gap/io.gi
+++ b/gap/io.gi
@@ -19,7 +19,7 @@
 BindGlobal( "FileFamily", NewFamily("FileFamily", IsFile) );
 
 # The type:
-InstallValue( FileType,
+BindGlobal( "FileType",
   NewType(FileFamily, IsFile and IsAttributeStoringRep));
 
 
@@ -38,13 +38,13 @@ else
     IO.NonBlockWriteAmount := 4096;
 fi;
 
-InstallValue( IO_Error,
+BindGlobal( "IO_Error",
   Objectify( NewType( IO_ResultsFamily, IO_Result ), rec( val := "IO_Error" ))
 );
-InstallValue( IO_Nothing,
+BindGlobal( "IO_Nothing",
   Objectify( NewType( IO_ResultsFamily, IO_Result ), rec( val := "IO_Nothing"))
 );
-InstallValue( IO_OK,
+BindGlobal( "IO_OK",
   Objectify( NewType( IO_ResultsFamily, IO_Result ), rec( val := "IO_OK"))
 );
 InstallMethod( \=, "for two IO_Results",

--- a/gap/pickle.gd
+++ b/gap/pickle.gd
@@ -9,7 +9,6 @@
 ##  This file contains functions for pickling and unpickling.
 ##
 
-DeclareGlobalVariable( "IO_PICKLECACHE" );
 DeclareGlobalFunction( "IO_ClearPickleCache" );
 DeclareGlobalFunction( "IO_AddToPickled" );
 DeclareGlobalFunction( "IO_IsAlreadyPickled" );

--- a/gap/pickle.gi
+++ b/gap/pickle.gi
@@ -13,7 +13,7 @@
 # (Un-)Pickling:
 #################
 
-InstallValue( IO_PICKLECACHE, rec( ids := [], nrs := [], obs := [],
+BindGlobal( "IO_PICKLECACHE", rec( ids := [], nrs := [], obs := [],
                                    depth := 0 ) );
 
 InstallGlobalFunction( IO_ClearPickleCache,


### PR DESCRIPTION
If we can get rid of all such uses of InstallValue, we can perhaps
eventually get rid of the GAP kernel function CLONE_OBJ.
