### PR TITLE
Avoid spurious failures in tst/sendstringbackground.tst

### DIFF
--- a/tst/sendstringbackground.tst
+++ b/tst/sendstringbackground.tst
@@ -1,5 +1,5 @@
 gap> f := IO_File("/dev/null", "w");;
-gap> IsBound(HPCGAP) or ForAll([1..3000], x -> IO_SendStringBackground(f, "cheese"));
+gap> IsBound(HPCGAP) or ForAll([1..1000], x -> IO_SendStringBackground(f, "cheese"));
 true
 gap> IO_Close(f);
 true


### PR DESCRIPTION
Each call to IO_SendStringBackground forks and then adds the resulting PID to a table with 1024 entries. If we fork much faster than those jobs can finish (e.g. because the machine has few cores and is under heavy load), and do it 3000 times (as we did so far), then this can result in the `ignoredpids` table overflowing.

So let's only do this 1000 times, not 3000.

Resolves #105
Resolves #108