### PR TITLE
Ensure `make doc` terminates, and indicates errors

### DIFF
--- a/Makefile.gappkg
+++ b/Makefile.gappkg
@@ -156,7 +156,7 @@ distclean-kext:
 # hook into `make doc`
 doc: doc-kext
 doc-kext:
-	$(GAP) makedoc.g
+	$(GAP) --quitonbreak -b -q < makedoc.g
 
 # hook into `make check`
 check: check-kext


### PR DESCRIPTION
Before this, `make doc` would end up in a GAP prompt, which is against any convention and makes it unusable in automation.

Also omit the GAP banner.

Fixes #100.