### PR TITLE
Move pkgconfig.h.in from gen to src

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,9 @@
 This file describes changes in the IO package.
 
 4.7.3 (YYYY-MM-DD)
+  - Fix a build issue where running `make clean` would break the build
+    system (and hence building this package via GAP's BuildPackages.sh
+    script was broken, as that always runs `make clean` first)
   - Various janitorial changes
 
 4.7.2 (2021-10-21)

--- a/Makefile.gappkg
+++ b/Makefile.gappkg
@@ -193,14 +193,14 @@ gen/pkgconfig.h: gen/pkgconfig.h.stamp
 	@if test ! -f $@; then rm -f $<; else :; fi
 	@if test ! -f $@; then $(MAKE) $<; else :; fi
 
-gen/pkgconfig.h.stamp: gen/pkgconfig.h.in config.status
+gen/pkgconfig.h.stamp: src/pkgconfig.h.in config.status
 	@rm -f $@
 	@mkdir -p $(@D)
 	./config.status gen/pkgconfig.h
 	echo > $@
 
 ifneq ($(MAINTAINER_MODE),no)
-gen/pkgconfig.h.in: $(configure_deps)
+src/pkgconfig.h.in: $(configure_deps)
 	@if command -v autoheader >/dev/null 2>&1 ; then \
 	   mkdir -p $(@D) ; \
 	   echo "running autoheader" ; \

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_PREREQ([2.68])
 AC_INIT([io], [package], [https://github.com/gap-packages/io/issues], [io], [https://gap-packages.github.io/io/])
 AC_CONFIG_SRCDIR([src/io.c])
-AC_CONFIG_HEADERS([gen/pkgconfig.h])
+AC_CONFIG_HEADERS([gen/pkgconfig.h:src/pkgconfig.h.in])
 AC_CONFIG_MACRO_DIR([m4])
 m4_include([m4/find_gap.m4])
 


### PR DESCRIPTION
The `gen` directory is for things that are created by `make` and it
is deleted by `make clean`. But `pkgconfig.h.in` is *not* generated by
`make`. So it does not belong into `src` but rather into `gen`.

Unfortunately GAP's `BuildPackages.sh` script runs `make clean` before
`make`, which triggered this bug.
