### PR TITLE
Properly close all open files on exit

### DIFF
--- a/gap/io.gi
+++ b/gap/io.gi
@@ -65,10 +65,15 @@ InstallMethod( ViewObj, "for an IO_Result",
 IO.OpenFiles := Set([]);
 InstallAtExit(function()
   local file;
-  for file in IO.OpenFiles do
+  # CAUTION: Calling IO_Close below removes the file from
+  # IO.OpenFiles, so iterating over IO.OpenFiles in a for-loop
+  # would skip every second file!
+  while Length(IO.OpenFiles) > 0 do
+      file := IO.OpenFiles[1];
       if IsBound(file!.dowaitpid) then
         Unbind(file!.dowaitpid);
       fi;
+      # this call removes the file from IO.OpenFiles
       IO_Close(file);
   od;
 end


### PR DESCRIPTION
The old logic iterated over a list while modifying this list, effectively skipping every second open file.

To avoid such errors in my own code, I have added an error to my GAP which triggers if I remove elements from a list while iterating over it: https://github.com/zickgraf/gap/commit/f8d4c3548275eef87bacb5c105ac230348cf4b01. Would this be a welcome change for GAP?