### PR TITLE
Check arguments to IO_gmtime and IO_localtime

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -1777,6 +1777,10 @@ static Obj FuncIO_gmtime(Obj self, Obj time)
     Obj         tmp;
     time_t      t;
     struct tm * s;
+    if (!IS_INT(time)) {
+        SyClearErrorNo();
+        return Fail;
+    }
     if (!IS_INTOBJ(time)) {
         tmp = QuoInt(time, INTOBJ_INT(256));
         if (!IS_INTOBJ(tmp))
@@ -1808,6 +1812,10 @@ static Obj FuncIO_localtime(Obj self, Obj time)
     Obj         tmp;
     time_t      t;
     struct tm * s;
+    if (!IS_INT(time)) {
+        SyClearErrorNo();
+        return Fail;
+    }
     if (!IS_INTOBJ(time)) {
         tmp = QuoInt(time, INTOBJ_INT(256));
         if (!IS_INTOBJ(tmp))


### PR DESCRIPTION
Fix #122 , we were not checking the type of arguments. I use the same checking style as the rest of IO, rather than the newer `Require` functions, for consistency.