### PR TITLE
Switch tests from neverssl.com to httpforever.com

### DIFF
--- a/tst/http.g
+++ b/tst/http.g
@@ -2,7 +2,7 @@
 
 LoadPackage("io");
 
-r := SingleHTTPRequest("neverssl.com",80,"GET",
+r := SingleHTTPRequest("httpforever.com",80,"GET",
         "/index.html",
         rec(),false,false);
 


### PR DESCRIPTION
The former has begun to return a 403 (though it works from the browser).
