### PR TITLE
Replace compiled.h by gap_all.h

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -11,7 +11,7 @@
 // Try to use as much of the GNU C library as possible:
 #define _GNU_SOURCE
 
-#include "compiled.h"    // GAP headers
+#include "gap_all.h"    // GAP headers
 
 #if GAP_KERNEL_MAJOR_VERSION >= 6
 #include "profile.h"


### PR DESCRIPTION
No functional change for this package but makes it future-proof.
