### PR TITLE
Remove include "profile.h"

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -13,10 +13,6 @@
 
 #include "gap_all.h"    // GAP headers
 
-#if GAP_KERNEL_MAJOR_VERSION >= 6
-#include "profile.h"
-#endif
-
 #undef PACKAGE
 #undef PACKAGE_BUGREPORT
 #undef PACKAGE_NAME


### PR DESCRIPTION
Removing it because gap_all.h is already included. For more context why we need this, please see: https://github.com/gap-system/gap/pull/6007