### PR TITLE
Make IO_fork children stoppable when GAP is embedded

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,12 @@
 This file describes changes in the IO package.
 
+4.10.1 (unreleased)
+  - Reset blocked/ignored/caught termination signals around IO_fork so that
+    children can be stopped with SIGTERM etc. even when a program embedding
+    GAP (e.g. julia via GAP.jl) redirects signal handling
+  - Make IO_WaitPid return instead of looping forever when the waited-for
+    process is not an unreaped child
+
 4.10.0 (2026-07-14)
   - Handle chunked HTTP responses without waiting for the server to close the
     connection

--- a/src/io.c
+++ b/src/io.c
@@ -317,6 +317,25 @@ static Obj FuncIO_WaitPid(Obj self, Obj pid, Obj wait)
         }
         // Really wait for something
         retcode = waitpid(-1, &status, (wait == True) ? 0 : WNOHANG);
+        if (retcode == -1 && errno == ECHILD) {
+            // There is no unreaped child left, so waiting cannot succeed;
+            // with wait = true, retrying would busy-loop forever. This
+            // happens when pid never was our child, or when something else
+            // in the process (another library, or a program embedding GAP)
+            // reaped it first and its status is lost. If the pid is gone,
+            // report it as terminated with unknown status.
+            signal(SIGCHLD, IO_SIGCHLDHandler);
+            if (kill((pid_t)pidc, 0) == -1 && errno == ESRCH) {
+                tmp = NEW_PREC(0);
+                AssPRec(tmp, RNamName("pid"), INTOBJ_INT(pidc));
+                AssPRec(tmp, RNamName("status"), Fail);
+                AssPRec(tmp, RNamName("WIFEXITED"), Fail);
+                AssPRec(tmp, RNamName("WEXITSTATUS"), Fail);
+                return tmp;
+            }
+            // pid still exists, but is not a child of this process
+            return (wait == True) ? Fail : False;
+        }
         IO_HandleChildSignal(retcode, status);
         reallytried = 1;    // Do not try again.
     } while (1);            // Left by break
@@ -1514,11 +1533,63 @@ static Obj FuncIO_select(Obj self,
 #ifdef HAVE_FORK
 static Obj FuncIO_fork(Obj self)
 {
-    int res;
+    // Make the termination signals a parent may send to stop the child
+    // work even if a program embedding GAP (e.g. julia via GAP.jl) blocks,
+    // ignores, or catches them with handlers depending on threads that do
+    // not survive the fork; any of these would leave the child unkillable
+    // except via SIGKILL. Unblock them, and mirror exec() semantics for
+    // their dispositions: caught becomes default action, SIG_IGN is kept
+    // (it may be deliberate, e.g. SIGHUP under nohup). SIGTERM is reset
+    // unconditionally: stopping children with it is part of IO_fork's
+    // contract (IO_kill, background jobs), and julia sets it to SIG_IGN.
+    //
+    // This must happen BEFORE the fork, restoring the state in the parent
+    // afterwards: a signal sent to a child that has not yet reset its
+    // inherited state would be discarded (SIG_IGN) or misdelivered, so
+    // resetting in the child would leave a race with a fast parent.
+    // The reset state also survives exec, so all this matters for
+    // fork+exec children, too.
+    static const int termsigs[] = { SIGHUP, SIGINT, SIGQUIT, SIGALRM,
+                                    SIGTERM };
+    enum { NUMTERMSIGS = sizeof(termsigs) / sizeof(termsigs[0]) };
+    struct sigaction saved_sa[NUMTERMSIGS];
+    int              saved_sa_ok[NUMTERMSIGS];
+    sigset_t         unblock, saved_mask;
+    size_t           i;
+    int              res;
+
     FuncIO_InstallSIGCHLDHandler(0);
     // Ensure files are flushed before forking
     fflush(0);
+
+    sigemptyset(&unblock);
+    for (i = 0; i < NUMTERMSIGS; i++) {
+        struct sigaction dfl;
+        sigaddset(&unblock, termsigs[i]);
+        saved_sa_ok[i] = (sigaction(termsigs[i], NULL, &saved_sa[i]) == 0);
+        if (!saved_sa_ok[i])
+            continue;
+        if (saved_sa[i].sa_handler == SIG_DFL ||
+            (saved_sa[i].sa_handler == SIG_IGN && termsigs[i] != SIGTERM))
+            continue;
+        memset(&dfl, 0, sizeof(dfl));
+        dfl.sa_handler = SIG_DFL;
+        sigemptyset(&dfl.sa_mask);
+        sigaction(termsigs[i], &dfl, NULL);
+    }
+    sigprocmask(SIG_UNBLOCK, &unblock, &saved_mask);
+
     res = fork();
+
+    if (res != 0) {
+        // In parent (or fork failed): restore the signal state
+        sigprocmask(SIG_SETMASK, &saved_mask, NULL);
+        for (i = 0; i < NUMTERMSIGS; i++) {
+            if (saved_sa_ok[i])
+                sigaction(termsigs[i], &saved_sa[i], NULL);
+        }
+    }
+
     if (res == -1) {
         SySetErrorNo();
         return Fail;

--- a/tst/forksignal.tst
+++ b/tst/forksignal.tst
@@ -7,7 +7,10 @@ gap> LoadPackage("IO", false);;
 # a regression fails instead of hanging.
 gap> pid := IO_fork();;
 gap> if pid = 0 then
->   # child: sleep, then exit in case the SIGTERM below never arrives
+>   # child: close the inherited line-by-line profile/coverage output (GAP
+>   # opens a per-child file; killed by a signal it would stay truncated),
+>   # then sleep, and exit in case the SIGTERM below never arrives
+>   if IsLineByLineProfileActive() then UnprofileLineByLine(); fi;
 >   IO_select([], [], [], 60, 0);
 >   IO_exit(0);
 > fi;

--- a/tst/forksignal.tst
+++ b/tst/forksignal.tst
@@ -1,0 +1,29 @@
+gap> START_TEST("forksignal.tst");
+gap> LoadPackage("IO", false);;
+
+# A child created by IO_fork must be terminable via SIGTERM even if the
+# hosting process blocks signals (e.g. julia embedding GAP via GAP.jl):
+# IO_fork resets the child's signal mask. Poll with a bounded timeout so
+# a regression fails instead of hanging.
+gap> pid := IO_fork();;
+gap> if pid = 0 then
+>   # child: sleep, then exit in case the SIGTERM below never arrives
+>   IO_select([], [], [], 60, 0);
+>   IO_exit(0);
+> fi;
+gap> pid > 0;
+true
+gap> IO_kill(pid, IO.SIGTERM);
+true
+gap> ret := false;;
+gap> for i in [1..100] do
+>   ret := IO_WaitPid(pid, false);
+>   if ret <> false then break; fi;
+>   IO_select([], [], [], 0, 100000);
+> od;
+
+# ret = false means the child survived SIGTERM for 10 seconds
+gap> IsRecord(ret) and ret.pid = pid;
+true
+gap> if ret = false then IO_kill(pid, IO.SIGKILL); IO_WaitPid(pid, true); fi;
+gap> STOP_TEST("forksignal.tst", 1);

--- a/tst/forksignal.tst
+++ b/tst/forksignal.tst
@@ -5,17 +5,23 @@ gap> LoadPackage("IO", false);;
 # hosting process blocks signals (e.g. julia embedding GAP via GAP.jl):
 # IO_fork resets the child's signal mask. Poll with a bounded timeout so
 # a regression fails instead of hanging.
+gap> p := IO_pipe();;
 gap> pid := IO_fork();;
 gap> if pid = 0 then
 >   # child: close the inherited line-by-line profile/coverage output (GAP
 >   # opens a per-child file; killed by a signal it would stay truncated),
->   # then sleep, and exit in case the SIGTERM below never arrives
+>   # tell the parent we are ready, then sleep, and exit in case the
+>   # SIGTERM below never arrives
 >   if IsLineByLineProfileActive() then UnprofileLineByLine(); fi;
+>   IO_write(p.towrite, "r", 0, 1);
 >   IO_select([], [], [], 60, 0);
 >   IO_exit(0);
 > fi;
 gap> pid > 0;
 true
+gap> ready := "";;
+gap> IO_read(p.toread, ready, 0, 1);
+1
 gap> IO_kill(pid, IO.SIGTERM);
 true
 gap> ret := false;;
@@ -29,4 +35,6 @@ gap> for i in [1..100] do
 gap> IsRecord(ret) and ret.pid = pid;
 true
 gap> if ret = false then IO_kill(pid, IO.SIGKILL); IO_WaitPid(pid, true); fi;
+gap> IO_close(p.toread);;
+gap> IO_close(p.towrite);;
 gap> STOP_TEST("forksignal.tst", 1);


### PR DESCRIPTION
A program embedding GAP may block termination signals, set them to `SIG_IGN`, or catch them with handlers that depend on threads which do not survive a fork; julia (GAP.jl) does all three. Children created by `IO_fork` then cannot be stopped by `IO_kill` with `SIGTERM`, so e.g. the test suites of curlInterface and utils, which fork an HTTP test server, hang in `IO_WaitPid` until killed from outside.

Reset the mask and dispositions of the common termination signals before forking (restoring them in the parent afterwards; resetting in the child instead would race against a parent that signals the child immediately, and a `SIGTERM` arriving before the reset would be discarded). Caught handlers are reset to the default action, `SIG_IGN` is kept except for `SIGTERM`, whose delivery is part of `IO_fork`'s contract.

Also make `IO_WaitPid` return instead of looping forever when `waitpid` reports `ECHILD`, i.e. when the waited-for process is not an unreaped child of ours.

Add a regression test; it fails under GAP.jl without the fix.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>