### PR TITLE
Reap only own children when GAP is embedded or HPC-GAP

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,10 @@ This file describes changes in the IO package.
     GAP (e.g. julia via GAP.jl) redirects signal handling
   - Make IO_WaitPid return instead of looping forever when the waited-for
     process is not an unreaped child
+  - Do not install a SIGCHLD handler in HPC-GAP or when GAP is embedded in
+    another program (e.g. julia via GAP.jl); wait only for the children
+    created by IO_fork, by process id, so that the host's own child
+    process handling keeps working (resolves issue #5)
 
 4.10.0 (2026-07-14)
   - Handle chunked HTTP responses without waiting for the server to close the

--- a/doc/main.xml
+++ b/doc/main.xml
@@ -1105,7 +1105,7 @@ See <Ref Func="IO_fork"/>.
 In HPC-GAP, and when &GAP; is used as a library inside another program
 (such as Julia via GAP.jl), no SIGCHLD handler is installed at all, and this
 function returns <K>false</K>: the host manages child processes itself, and
-&IO; only ever waits for the children it created, by process id. All
+<Package>IO</Package> only ever waits for the children it created, by process id. All
 functions described here behave the same in both modes.
 </Description>
 </ManSection>

--- a/doc/main.xml
+++ b/doc/main.xml
@@ -479,7 +479,12 @@ For details see <Q><C>man 2 fork</C></Q>.
 Note that <Ref Func="IO_fork"/> activates our SIGCHLD handler (see <Ref
 Func="IO_InstallSIGCHLDHandler"/>). Note that you must use the
 <Ref Func="IO_WaitPid"/> function to wait or check for the termination of
-child processes, or call <Ref Func="IO_IgnorePid"/> to ignore the child. 
+child processes, or call <Ref Func="IO_IgnorePid"/> to ignore the child.
+<P/>
+The child starts with the signal mask and the dispositions of the
+termination signals (SIGHUP, SIGINT, SIGQUIT, SIGALRM, SIGTERM) reset to
+their defaults, even if the process embedding &GAP; had blocked or ignored
+them, so that it can be stopped with <Ref Func="IO_kill"/>.
 </Description>
 </ManSection>
 
@@ -1096,6 +1101,12 @@ automatically called by any function which creates new processes,
 so never needs to be called unless the handler was explictly disabled with
 <Ref Func="IO_RestoreSIGCHLDHandler"/>
 See <Ref Func="IO_fork"/>.
+<P/>
+In HPC-GAP, and when &GAP; is used as a library inside another program
+(such as Julia via GAP.jl), no SIGCHLD handler is installed at all, and this
+function returns <K>false</K>: the host manages child processes itself, and
+&IO; only ever waits for the children it created, by process id. All
+functions described here behave the same in both modes.
 </Description>
 </ManSection>
 

--- a/src/io.c
+++ b/src/io.c
@@ -173,6 +173,147 @@ static int IO_CheckForIgnoredPid(int pid);
 
 static void (*oldhandler)(int whichsig) = 0;    // the old handler
 
+/***********************************************************************
+ * Child reaping strategy.
+ *
+ * In standalone GAP the SIGCHLD handler above reaps every child with
+ * waitpid(-1) and queues the statuses in the FIFO. That is unusable when
+ * something else in the process manages children of its own: HPC-GAP
+ * handles SIGCHLD on a dedicated thread, and a program embedding GAP as a
+ * library (e.g. julia via GAP.jl) reaps its subprocesses per pid; a foreign
+ * SIGCHLD handler or a waitpid(-1) stealing their statuses makes them hang.
+ *
+ *                       standalone GAP        HPC-GAP / embedded GAP
+ *   SIGCHLD handler     IO_SIGCHLDHandler     none
+ *   reaping             waitpid(-1) in the    waitpid(pid) on demand, for
+ *                       handler, FIFO         pids registered by IO_fork
+ *
+ * In the second mode io keeps a registry of the children it forked itself
+ * and touches no other process.
+ ***********************************************************************/
+static int use_sigchld_handler = 1;
+
+typedef struct {
+    int pid;
+    int ignored;    // disowned via IO_IgnorePid: reap and forget
+} OwnChild;
+
+static OwnChild ownchildren[MAXCHLDS];
+static int      numownchildren = 0;
+
+static void RegisterOwnChild(int pid)
+{
+    if (numownchildren >= MAXCHLDS) {
+        Pr("#E Overflow in table of child processes\n", 0, 0);
+        return;
+    }
+    ownchildren[numownchildren].pid = pid;
+    ownchildren[numownchildren].ignored = 0;
+    numownchildren++;
+}
+
+static int FindOwnChild(int pid)
+{
+    for (int i = 0; i < numownchildren; i++)
+        if (ownchildren[i].pid == pid)
+            return i;
+    return -1;
+}
+
+static void ForgetOwnChild(int i)
+{
+    ownchildren[i] = ownchildren[--numownchildren];
+}
+
+// Reap disowned children that have exited, so they do not linger as
+// zombies; called whenever io deals with child processes anyway.
+static void ReapIgnoredOwnChildren(void)
+{
+    int i = 0;
+    while (i < numownchildren) {
+        int status;
+        if (ownchildren[i].ignored &&
+            waitpid(ownchildren[i].pid, &status, WNOHANG) != 0)
+            ForgetOwnChild(i);    // exited, or not our child any more
+        else
+            i++;
+    }
+}
+
+static Obj MakeWaitPidRecord(int pid, int status)
+{
+    Obj tmp = NEW_PREC(0);
+    AssPRec(tmp, RNamName("pid"), INTOBJ_INT(pid));
+    AssPRec(tmp, RNamName("status"), INTOBJ_INT(status));
+    AssPRec(tmp, RNamName("WIFEXITED"), INTOBJ_INT(WIFEXITED(status)));
+    AssPRec(tmp, RNamName("WEXITSTATUS"), INTOBJ_INT(WEXITSTATUS(status)));
+    return tmp;
+}
+
+// The status of <pid> is not available any more: it never was our child,
+// or something else in the process reaped it first. Report it as
+// terminated with unknown status if it is gone.
+static Obj WaitPidStatusLost(int pid, int wait)
+{
+    if (kill((pid_t)pid, 0) == -1 && errno == ESRCH) {
+        Obj tmp = NEW_PREC(0);
+        AssPRec(tmp, RNamName("pid"), INTOBJ_INT(pid));
+        AssPRec(tmp, RNamName("status"), Fail);
+        AssPRec(tmp, RNamName("WIFEXITED"), Fail);
+        AssPRec(tmp, RNamName("WEXITSTATUS"), Fail);
+        return tmp;
+    }
+    // pid still exists, but is not a child of this process
+    return wait ? Fail : False;
+}
+
+// IO_WaitPid without a SIGCHLD handler: wait for one specific registered
+// child, or (pid = -1) for any of them, polling in the latter case.
+static Obj WaitForOwnChild(int pid, int wait)
+{
+    ReapIgnoredOwnChildren();
+
+    if (pid != -1) {
+        int status, retcode;
+        do {
+            retcode = waitpid(pid, &status, wait ? 0 : WNOHANG);
+        } while (retcode == -1 && errno == EINTR);
+        if (retcode == 0)
+            return False;
+        if (retcode == -1)
+            return WaitPidStatusLost(pid, wait);
+        int i = FindOwnChild(pid);
+        if (i != -1)
+            ForgetOwnChild(i);
+        return MakeWaitPidRecord(pid, status);
+    }
+
+    while (1) {
+        int waiting = 0;
+        for (int i = 0; i < numownchildren; i++) {
+            int status, retcode;
+            if (ownchildren[i].ignored)
+                continue;
+            retcode = waitpid(ownchildren[i].pid, &status, WNOHANG);
+            if (retcode == -1) {
+                ForgetOwnChild(i--);    // not our child any more
+                continue;
+            }
+            if (retcode == 0) {
+                waiting++;
+                continue;
+            }
+            ForgetOwnChild(i);
+            return MakeWaitPidRecord(retcode, status);
+        }
+        if (waiting == 0)
+            return Fail;    // nothing to wait for
+        if (!wait)
+            return False;
+        usleep(10000);
+    }
+}
+
 static void IO_HandleChildSignal(int retcode, int status)
 {
     if (retcode > 0) {    // One of our child processes terminated
@@ -215,6 +356,12 @@ void IO_SIGCHLDHandler(int whichsig)
 
 static Obj FuncIO_InstallSIGCHLDHandler(Obj self)
 {
+    if (!use_sigchld_handler) {
+        // still needed: writing to a pipe whose reader is gone must not
+        // kill the process
+        signal(SIGPIPE, SIG_IGN);
+        return False;
+    }
     // Do not install ourselves twice:
     if (oldhandler == 0) {
         oldhandler = signal(SIGCHLD, IO_SIGCHLDHandler);
@@ -226,7 +373,7 @@ static Obj FuncIO_InstallSIGCHLDHandler(Obj self)
 
 static Obj FuncIO_RestoreSIGCHLDHandler(Obj self)
 {
-    if (oldhandler == 0)
+    if (!use_sigchld_handler || oldhandler == 0)
         return False;
 
     signal(SIGCHLD, oldhandler);
@@ -267,6 +414,18 @@ static Obj FuncIO_IgnorePid(Obj self, Obj pid)
         return Fail;
     }
 
+    if (!use_sigchld_handler) {
+        int i = FindOwnChild(pidc);
+        if (i == -1) {
+            RegisterOwnChild(pidc);
+            i = FindOwnChild(pidc);
+        }
+        if (i != -1)
+            ownchildren[i].ignored = 1;
+        ReapIgnoredOwnChildren();
+        return True;
+    }
+
     // Make sure a new signal doesn't come in while we are changing array
     signal(SIGCHLD, SIG_DFL);
 
@@ -302,9 +461,13 @@ static Obj FuncIO_WaitPid(Obj self, Obj pid, Obj wait)
         SyClearErrorNo();
         return Fail;
     }
+    pidc = INT_INTOBJ(pid);
+
+    if (!use_sigchld_handler)
+        return WaitForOwnChild(pidc, wait == True);
+
     // First set SIGCHLD to default action to avoid clashes with access:
     signal(SIGCHLD, SIG_DFL);
-    pidc = INT_INTOBJ(pid);
     reallytried = 0;
     do {
         pos = findSignaledPid(pidc);
@@ -325,26 +488,12 @@ static Obj FuncIO_WaitPid(Obj self, Obj pid, Obj wait)
             // reaped it first and its status is lost. If the pid is gone,
             // report it as terminated with unknown status.
             signal(SIGCHLD, IO_SIGCHLDHandler);
-            if (kill((pid_t)pidc, 0) == -1 && errno == ESRCH) {
-                tmp = NEW_PREC(0);
-                AssPRec(tmp, RNamName("pid"), INTOBJ_INT(pidc));
-                AssPRec(tmp, RNamName("status"), Fail);
-                AssPRec(tmp, RNamName("WIFEXITED"), Fail);
-                AssPRec(tmp, RNamName("WEXITSTATUS"), Fail);
-                return tmp;
-            }
-            // pid still exists, but is not a child of this process
-            return (wait == True) ? Fail : False;
+            return WaitPidStatusLost(pidc, wait == True);
         }
         IO_HandleChildSignal(retcode, status);
         reallytried = 1;    // Do not try again.
     } while (1);            // Left by break
-    tmp = NEW_PREC(0);
-    AssPRec(tmp, RNamName("pid"), INTOBJ_INT(pids[pos]));
-    AssPRec(tmp, RNamName("status"), INTOBJ_INT(stats[pos]));
-    AssPRec(tmp, RNamName("WIFEXITED"), INTOBJ_INT(WIFEXITED(stats[pos])));
-    AssPRec(tmp, RNamName("WEXITSTATUS"),
-            INTOBJ_INT(WEXITSTATUS(stats[pos])));
+    tmp = MakeWaitPidRecord(pids[pos], stats[pos]);
 
     // Dequeue element:
     removeSignaledPidByPos(pos);
@@ -1594,12 +1743,16 @@ static Obj FuncIO_fork(Obj self)
         SySetErrorNo();
         return Fail;
     }
-#if GAP_KERNEL_MAJOR_VERSION >= 6
     if (res == 0) {
-        // In child
+        // In child: the parent's children are not ours
+        numownchildren = 0;
+#if GAP_KERNEL_MAJOR_VERSION >= 6
         InformProfilingThatThisIsAForkedGAP();
-    }
 #endif
+    }
+    else if (!use_sigchld_handler) {
+        RegisterOwnChild(res);
+    }
     return INTOBJ_INT(res);
 }
 #endif
@@ -2235,6 +2388,13 @@ static Int InitKernel(StructInitInfo * module)
 {
     // init filters and functions
     InitHdlrFuncsFromTable(GVarFuncs);
+
+    // see "Child reaping strategy" above
+#ifdef HPCGAP
+    use_sigchld_handler = 0;
+#else
+    use_sigchld_handler = !IsUsingLibGap();
+#endif
 
     // return success
     return 0;

--- a/src/io.c
+++ b/src/io.c
@@ -268,7 +268,11 @@ static Obj WaitPidStatusLost(int pid, int wait)
 }
 
 // IO_WaitPid without a SIGCHLD handler: wait for one specific registered
-// child, or (pid = -1) for any of them, polling in the latter case.
+// child, or (pid = -1) for any of them. The latter has to poll: waitpid()
+// blocks on a single pid or on all children (which would steal the host's),
+// and waiting for SIGCHLD would compete with the host's own handler.
+#define OWN_CHILD_POLL_INTERVAL_USEC 10000
+
 static Obj WaitForOwnChild(int pid, int wait)
 {
     ReapIgnoredOwnChildren();
@@ -310,7 +314,7 @@ static Obj WaitForOwnChild(int pid, int wait)
             return Fail;    // nothing to wait for
         if (!wait)
             return False;
-        usleep(10000);
+        usleep(OWN_CHILD_POLL_INTERVAL_USEC);
     }
 }
 


### PR DESCRIPTION
The SIGCHLD handler reaps every child with waitpid(-1) and queues the statuses. That breaks any other party managing children in the same process: HPC-GAP's signal thread (issue #5), and programs embedding GAP such as julia, whose libuv reaps its subprocesses per pid and hangs forever once io has stolen a status (GAP.jl#902).

In those two settings install no handler; instead keep a registry of the children created by IO_fork and wait for them with waitpid(pid), on demand. IO_IgnorePid marks a registered child to be reaped whenever io next deals with children, and IO_WaitPid(-1, ...) polls the registry. Standalone GAP keeps the handler and the FIFO unchanged.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

CC @lgoettgens

Progress towards issue #5 (I am not sure when exactly we can declare that one to be resolved)