### PR TITLE
Make the package build for native Windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,6 +27,8 @@ AC_CHECK_HEADERS_ONCE([
     unistd.h
 ])
 
+AC_CHECK_MEMBERS([struct stat.st_blksize, struct stat.st_blocks])
+
 # Checks for library functions.
 AC_FUNC_FORK
 AC_CHECK_FUNCS_ONCE([
@@ -38,6 +40,7 @@ AC_CHECK_FUNCS_ONCE([
     connect
     dup
     dup2
+    fcntl
     fchmod
     fchown
     fstat
@@ -64,8 +67,10 @@ AC_CHECK_FUNCS_ONCE([
     mknod
     mkstemp
     opendir
+    pipe
     readdir
     readlink
+    realpath
     recv
     recvfrom
     rename

--- a/gap/unavailable.g
+++ b/gap/unavailable.g
@@ -1,0 +1,44 @@
+#############################################################################
+##
+##  unavailable.g            The IO package
+##
+##  Stubs for kernel functions which are not available on this platform.
+##
+
+#
+# The C part registers each of the functions below only when configure found
+# the system call it wraps, so which ones exist depends on the platform. On
+# native Windows, for instance, there is no fork and there are no signals.
+#
+# Bind the missing ones here, before any of the GAP code that mentions them
+# is read: without this, reading it warns about unbound globals, and calling
+# one of them fails with a message that says nothing about the real reason.
+#
+BindGlobal( "IO_UnavailableFunc", function( name )
+    return function( arg )
+        Error( name, " is not available on this platform" );
+    end;
+end );
+
+BindGlobal( "IO_MaybeUnavailable", [
+  "IO_IgnorePid", "IO_InstallSIGCHLDHandler", "IO_RestoreSIGCHLDHandler",
+  "IO_WaitPid", "IO_accept", "IO_bind", "IO_chmod", "IO_chown",
+  "IO_closedir", "IO_connect", "IO_dup", "IO_dup2", "IO_fchmod",
+  "IO_fchown", "IO_fcntl", "IO_fork", "IO_fstat", "IO_gethostbyname",
+  "IO_gethostname", "IO_getpid", "IO_getppid", "IO_getsockname",
+  "IO_getsockopt", "IO_gettimeofday", "IO_gmtime", "IO_kill",
+  "IO_lchown", "IO_link", "IO_listen", "IO_localtime", "IO_lstat",
+  "IO_make_sockaddr_in", "IO_mkdir", "IO_mkdtemp", "IO_mkfifo",
+  "IO_mknod", "IO_mkstemp", "IO_opendir", "IO_pipe", "IO_readdir",
+  "IO_readlink", "IO_recv", "IO_recvfrom", "IO_rename", "IO_rewinddir",
+  "IO_rmdir", "IO_seekdir", "IO_select", "IO_send", "IO_sendto",
+  "IO_setsockopt", "IO_socket", "IO_stat", "IO_symlink", "IO_telldir",
+  "IO_unlink"
+] );
+
+for IO_name in IO_MaybeUnavailable do
+    if not IsBoundGlobal( IO_name ) then
+        BindGlobal( IO_name, IO_UnavailableFunc( IO_name ) );
+    fi;
+od;
+Unbind( IO_name );

--- a/init.g
+++ b/init.g
@@ -17,6 +17,9 @@ if not LoadKernelExtension("io") then
   Error("failed to load the io package kernel extension");
 fi;
 
+# must come first: it binds the kernel functions this platform lacks
+ReadPackage("IO", "gap/unavailable.g");
+
 ReadPackage("IO", "gap/io.gd");
 ReadPackage("IO", "gap/pickle.gd");
 ReadPackage("IO", "gap/realrandom.gd");

--- a/src/io.c
+++ b/src/io.c
@@ -38,6 +38,15 @@
 #include <time.h>
 #endif
 #include <errno.h>
+#ifdef _WIN32
+#include <direct.h>    // for _mkdir
+#endif
+
+// Tracking child processes needs SIGCHLD and waitpid, which native Windows
+// lacks; without them IO cannot run subprocesses at all.
+#if defined(HAVE_SIGNAL) && defined(HAVE_SYS_WAIT_H) && defined(SIGCHLD)
+#define IO_HAVE_SIGCHLD 1
+#endif
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif
@@ -103,6 +112,8 @@
  * coming from streams is stored in one data structure here, such that
  * we can read it out from GAP using IO.Wait.
  ***********************************************************************/
+
+#ifdef IO_HAVE_SIGCHLD
 
 // FIXME: globals
 
@@ -200,7 +211,6 @@ static void IO_HandleChildSignal(int retcode, int status)
     }
 }
 
-#ifdef HAVE_SIGNAL
 void IO_SIGCHLDHandler(int whichsig)
 {
     int retcode, status;
@@ -352,7 +362,7 @@ static Obj FuncIO_WaitPid(Obj self, Obj pid, Obj wait)
     signal(SIGCHLD, IO_SIGCHLDHandler);
     return tmp;
 }
-#endif
+#endif    // IO_HAVE_SIGCHLD
 
 static Obj FuncIO_open(Obj self, Obj path, Obj flags, Obj mode)
 {
@@ -689,7 +699,11 @@ static Obj FuncIO_realpath(Obj self, Obj path)
     }
 
     char buf[PATH_MAX];
+#ifdef _WIN32
+    if (_fullpath(buf, CSTR_STRING(path), sizeof(buf))) {
+#else
     if (realpath(CSTR_STRING(path), buf)) {
+#endif
         return MakeImmString(buf);
     }
 
@@ -737,7 +751,12 @@ static Obj FuncIO_mkdir(Obj self, Obj pathname, Obj mode)
         return Fail;
     }
 
+#ifdef _WIN32
+    // Windows has no file permission bits, so <mode> is ignored
+    res = _mkdir(CSTR_STRING(pathname));
+#else
     res = mkdir(CSTR_STRING(pathname), INT_INTOBJ(mode));
+#endif
     if (res < 0) {
         SySetErrorNo();
         return Fail;
@@ -777,8 +796,12 @@ static Obj WrapStat(struct stat * statbuf)
     AssPRec(rec, RNamName("gid"), ObjInt_UInt(statbuf->st_gid));
     AssPRec(rec, RNamName("rdev"), ObjInt_UInt8(statbuf->st_rdev));
     AssPRec(rec, RNamName("size"), ObjInt_Int8(statbuf->st_size));
+#ifdef HAVE_STRUCT_STAT_ST_BLKSIZE
     AssPRec(rec, RNamName("blksize"), ObjInt_Int8(statbuf->st_blksize));
+#endif
+#ifdef HAVE_STRUCT_STAT_ST_BLOCKS
     AssPRec(rec, RNamName("blocks"), ObjInt_Int8(statbuf->st_blocks));
+#endif
     AssPRec(rec, RNamName("atime"), ObjInt_Int(statbuf->st_atime));
     AssPRec(rec, RNamName("mtime"), ObjInt_Int(statbuf->st_mtime));
     AssPRec(rec, RNamName("ctime"), ObjInt_Int(statbuf->st_ctime));
@@ -1725,7 +1748,12 @@ static Obj FuncIO_execve(Obj self, Obj path, Obj Argv, Obj Envp)
     return Fail;
 }
 
+#ifdef _WIN32
+// mingw declares _environ in stdlib.h
+#define environ _environ
+#else
 extern char ** environ;
+#endif
 
 static Obj FuncIO_environ(Obj self)
 {
@@ -1749,6 +1777,7 @@ static Obj FuncIO_environ(Obj self)
     return tmp;
 }
 
+#ifdef HAVE_PIPE
 static Obj FuncIO_pipe(Obj self)
 {
     Obj tmp;
@@ -1765,6 +1794,7 @@ static Obj FuncIO_pipe(Obj self)
     AssPRec(tmp, RNamName("towrite"), INTOBJ_INT(fds[1]));
     return tmp;
 }
+#endif
 
 static Obj FuncIO_exit(Obj self, Obj status)
 {
@@ -1777,7 +1807,7 @@ static Obj FuncIO_exit(Obj self, Obj status)
     return True;
 }
 
-#ifdef HAVE_FCNTL_H
+#ifdef HAVE_FCNTL
 static Obj FuncIO_fcntl(Obj self, Obj fd, Obj cmd, Obj arg)
 {
     int res;
@@ -1959,8 +1989,14 @@ static Obj FuncIO_setenv(Obj self, Obj name, Obj value, Obj overwrite)
         SyClearErrorNo();
         return Fail;
     }
+#ifdef _WIN32
+    // _putenv_s always overwrites
+    int res = _putenv_s(CONST_CSTR_STRING(name), CONST_CSTR_STRING(value));
+    (void)overwrite;
+#else
     int res = setenv(CONST_CSTR_STRING(name), CONST_CSTR_STRING(value),
                      overwrite == True);
+#endif
     if (res < 0) {
         SySetErrorNo();
         return Fail;
@@ -1974,7 +2010,12 @@ static Obj FuncIO_unsetenv(Obj self, Obj name)
         SyClearErrorNo();
         return Fail;
     }
+#ifdef _WIN32
+    // assigning the empty value removes the variable
+    int res = _putenv_s(CONST_CSTR_STRING(name), "");
+#else
     int res = unsetenv(CONST_CSTR_STRING(name));
+#endif
     if (res < 0) {
         SySetErrorNo();
         return Fail;
@@ -2166,8 +2207,10 @@ static StructGVarFunc GVarFuncs[] = {
         IO_select, 5, "inlist, outlist, exclist, timeoutsec, timeoutusec"),
 #endif
 
+#ifdef IO_HAVE_SIGCHLD
     GVAR_FUNC(IO_IgnorePid, 1, "pid"),
-#if defined(HAVE_SIGACTION) || defined(HAVE_SIGNAL)
+#endif
+#ifdef IO_HAVE_SIGCHLD
     GVAR_FUNC(IO_WaitPid, 2, "pid, wait"),
 #endif
 
@@ -2179,14 +2222,16 @@ static StructGVarFunc GVarFuncs[] = {
     GVAR_FUNC(IO_execvp, 2, "path, argv"),
     GVAR_FUNC(IO_execve, 3, "path, argv, envp"),
     GVAR_FUNC(IO_environ, 0, ""),
-#ifdef HAVE_SIGNAL
+#ifdef IO_HAVE_SIGCHLD
     GVAR_FUNC(IO_InstallSIGCHLDHandler, 0, ""),
     GVAR_FUNC(IO_RestoreSIGCHLDHandler, 0, ""),
 #endif
 
+#ifdef HAVE_PIPE
     GVAR_FUNC(IO_pipe, 0, ""),
+#endif
     GVAR_FUNC(IO_exit, 1, "status"),
-#ifdef HAVE_FCNTL_H
+#ifdef HAVE_FCNTL
     GVAR_FUNC(IO_fcntl, 3, "fd, cmd, arg"),
 #endif
 

--- a/src/io.c
+++ b/src/io.c
@@ -43,8 +43,10 @@
 #endif
 
 // Tracking child processes needs SIGCHLD and waitpid, which native Windows
-// lacks; without them IO cannot run subprocesses at all.
-#if defined(HAVE_SIGNAL) && defined(HAVE_SYS_WAIT_H) && defined(SIGCHLD)
+// lacks; without them IO cannot run subprocesses at all. Decided from the
+// configure results alone: whether <signal.h> has been included by this
+// point, and so whether SIGCHLD is visible, differs between platforms.
+#if defined(HAVE_SIGNAL_H) && defined(HAVE_SIGNAL) && defined(HAVE_SYS_WAIT_H)
 #define IO_HAVE_SIGCHLD 1
 #endif
 #ifdef HAVE_SYS_STAT_H


### PR DESCRIPTION
On mingw the package failed to compile, so it was unavailable together with everything depending on it. Guard what native Windows lacks and use its equivalent where there is one:

- child processes need SIGCHLD and waitpid; the new IO_HAVE_SIGCHLD covers the bookkeeping, the handlers and IO_WaitPid
- IO_realpath uses _fullpath, IO_mkdir uses _mkdir (which has no mode argument), IO_setenv and IO_unsetenv use _putenv_s
- IO_pipe and IO_fcntl are guarded by new configure checks, as is st_blksize and st_blocks in the record IO_stat returns
- environ is spelled _environ

38 of the 72 functions remain, enough for files, directories, streams and pickling. Sockets are absent for now; they need Winsock.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>